### PR TITLE
Add macOS Relay proxy v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Compile
+        run: PYTHONPATH=src python -m compileall -q src tests
+      - name: Unit tests
+        run: PYTHONPATH=src python -m unittest discover -s tests -v
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+__pycache__/
+*.py[cod]
 node_modules/
 dist/
 tmp/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,127 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal Entity
+authorized to submit on behalf of the copyright owner.
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License.
+
+END OF TERMS AND CONDITIONS
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,55 @@
-# LiteLLM Relay V0 Scope
+# LiteLLM Relay
 
-This repo currently contains the standalone product-scope artifact for a proposed machine-installed LiteLLM Relay agent.
+LiteLLM Relay is a local endpoint agent that helps route and shadow AI app traffic
+through LiteLLM Gateway. V0 focuses on macOS manual pilots and MDM-friendly PAC
+deployment for Notion Mac app traffic.
 
-Open `index.html` in a browser to review:
+## V0 scope
 
-- Product positioning and name candidates
-- V0 architecture
-- Notion Mac app interception proof path
-- GitHub repo structure
-- Implementation milestones and risks
+- Starts a local HTTP CONNECT proxy on `127.0.0.1:4142`.
+- Serves a PAC file at `http://127.0.0.1:4142/proxy.pac`.
+- Routes Notion domains through Relay when the PAC is installed.
+- Logs redacted Notion connection metadata to `~/.litellm-relay/relay.log.jsonl`.
+- Optionally sends a synthetic shadow event through LiteLLM Gateway for audit correlation.
 
-The live local proof in the artifact is intentionally metadata-only. Full HTTPS request interception for the Notion Mac app requires a managed proxy profile and trusted enterprise CA on a test Mac.
+V0 does **not** decrypt TLS, capture Notion prompts, capture cookies, or rewrite
+Notion private APIs. That requires a managed enterprise CA and a Notion-specific
+adapter, which is intentionally outside this first OSS cut.
+
+## Manual install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh | bash
+```
+
+To immediately route Notion traffic on a pilot Mac:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh \
+  | bash -s -- --set-system-proxy "Wi-Fi"
+```
+
+To enable Gateway shadow calls:
+
+```bash
+export LITELLM_GATEWAY_URL="https://gateway.example.com"
+export LITELLM_GATEWAY_API_KEY="sk-..."
+export LITELLM_RELAY_SHADOW_ENABLED=1
+
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh \
+  | bash -s -- --set-system-proxy "Wi-Fi"
+```
+
+## Local development
+
+```bash
+PYTHONPATH=src python3 -m litellm_relay.cli serve
+PYTHONPATH=src python3 -m litellm_relay.cli pac
+PYTHONPATH=src python3 -m unittest discover -s tests
+```
+
+## Docs
+
+- [Notion AI shadowing v0](docs/notion-shadow-v0.md)
+- [MDM rollout](docs/mdm.md)
+- [Product scope artifact](index.html)

--- a/docs/mdm.md
+++ b/docs/mdm.md
@@ -1,0 +1,48 @@
+# MDM rollout
+
+LiteLLM Relay v0 supports the same rollout shape buyers expect for endpoint
+software: manual pilot first, then Jamf, Intune, or Kandji.
+
+## Manual pilot
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh | bash
+```
+
+To route Notion traffic immediately:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh \
+  | bash -s -- --set-system-proxy "Wi-Fi"
+```
+
+## Jamf
+
+1. Package this repo as a signed macOS package.
+2. Deploy the package to the pilot scope.
+3. Deploy a configuration profile with an Auto Proxy URL:
+   `http://127.0.0.1:4142/proxy.pac`.
+4. Set environment values through a managed LaunchAgent plist or a future Relay
+   enrollment profile:
+   - `LITELLM_GATEWAY_URL`
+   - `LITELLM_RELAY_SHADOW_ENABLED`
+   - `LITELLM_RELAY_SHADOW_MODEL`
+
+## Intune
+
+1. Deploy the package as a macOS line-of-business app.
+2. Deploy a custom configuration profile for PAC/system proxy settings.
+3. Use Intune trusted certificate profiles only when testing a future MITM mode.
+
+## Kandji
+
+1. Upload the package as a Custom App.
+2. Deploy a custom profile with the PAC URL.
+3. Use a Certificate Library Item only for a future managed-CA MITM test.
+
+## Notes
+
+macOS has a single Global HTTP Proxy payload per device. Customers already using
+a corporate proxy need a coordinated PAC file instead of a second competing
+profile.
+

--- a/docs/notion-shadow-v0.md
+++ b/docs/notion-shadow-v0.md
@@ -1,0 +1,62 @@
+# Notion AI shadowing v0
+
+LiteLLM Relay v0 shadows Notion Mac app traffic at the proxy metadata layer.
+It does not decrypt TLS and does not capture Notion prompts, page text, cookies,
+workspace IDs, or response bodies.
+
+## What v0 proves
+
+1. A managed Mac can route Notion domains through a local Relay proxy using PAC.
+2. Relay can identify Notion destination hosts from `CONNECT` requests.
+3. Relay can write redacted JSONL connection events.
+4. Relay can optionally send a synthetic shadow event through LiteLLM Gateway so
+   Gateway logs prove the event path works end to end.
+
+## Install for a manual pilot
+
+```bash
+git clone https://github.com/BerriAI/litellm-relay.git
+cd litellm-relay
+
+export LITELLM_GATEWAY_URL="https://gateway.example.com"
+export LITELLM_GATEWAY_API_KEY="sk-..."
+export LITELLM_RELAY_SHADOW_ENABLED=1
+
+./install.sh --set-system-proxy "Wi-Fi"
+```
+
+Trigger Notion AI in the Notion Mac app, then inspect:
+
+```bash
+tail -f ~/.litellm-relay/relay.log.jsonl
+```
+
+Expected redacted event:
+
+```json
+{
+  "event": "connect",
+  "host": "www.notion.so",
+  "method": "CONNECT",
+  "notion_match": true,
+  "port": 443,
+  "shadow": {
+    "attempted": true,
+    "ok": true,
+    "status": 200
+  }
+}
+```
+
+## Why this is not MITM
+
+Notion AI uses Notion private APIs over HTTPS. Routing those private requests
+through LiteLLM Gateway as real completions requires:
+
+- a managed enterprise CA trusted by the Mac,
+- explicit domain allowlisting,
+- a Notion private API adapter,
+- Notion-compatible response synthesis.
+
+That is intentionally outside v0. V0 establishes the install, routing, logging,
+and Gateway shadow-call path first.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELAY_HOME="${RELAY_HOME:-$HOME/.litellm-relay}"
+RELAY_PORT="${LITELLM_RELAY_PORT:-4142}"
+NETWORK_SERVICE=""
+
+usage() {
+  cat <<'USAGE'
+Install LiteLLM Relay on macOS.
+
+Usage:
+  ./install.sh [--set-system-proxy "Wi-Fi"]
+
+Environment:
+  LITELLM_GATEWAY_URL              LiteLLM Gateway URL, default http://127.0.0.1:4000
+  LITELLM_GATEWAY_API_KEY          Gateway virtual key for shadow calls
+  LITELLM_RELAY_SHADOW_ENABLED     Set to 1 to shadow Notion connection events
+  LITELLM_RELAY_SHADOW_MODEL       Model for synthetic shadow calls, default gpt-4o-mini
+
+By default this installs and starts the local Relay LaunchAgent but does not
+change system proxy settings. Pass --set-system-proxy "Wi-Fi" for a manual pilot.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --set-system-proxy)
+      NETWORK_SERVICE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "install.sh v0 currently supports macOS only." >&2
+  exit 1
+fi
+
+mkdir -p "$RELAY_HOME"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -d "$SCRIPT_DIR/src/litellm_relay" ]]; then
+  rsync -a --delete "$SCRIPT_DIR/src/" "$RELAY_HOME/src/"
+else
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$TMP_DIR"' EXIT
+  curl -fsSL "https://github.com/BerriAI/litellm-relay/archive/refs/heads/main.tar.gz" \
+    | tar -xz -C "$TMP_DIR"
+  rsync -a --delete "$TMP_DIR/litellm-relay-main/src/" "$RELAY_HOME/src/"
+fi
+
+cat > "$RELAY_HOME/env" <<ENV
+LITELLM_RELAY_HOST=127.0.0.1
+LITELLM_RELAY_PORT=$RELAY_PORT
+LITELLM_RELAY_LOG_PATH=$RELAY_HOME/relay.log.jsonl
+LITELLM_GATEWAY_URL=${LITELLM_GATEWAY_URL:-http://127.0.0.1:4000}
+LITELLM_GATEWAY_API_KEY=${LITELLM_GATEWAY_API_KEY:-}
+LITELLM_RELAY_SHADOW_ENABLED=${LITELLM_RELAY_SHADOW_ENABLED:-0}
+LITELLM_RELAY_SHADOW_MODEL=${LITELLM_RELAY_SHADOW_MODEL:-gpt-4o-mini}
+ENV
+chmod 600 "$RELAY_HOME/env"
+
+mkdir -p "$RELAY_HOME/bin"
+cat > "$RELAY_HOME/bin/run-relay" <<RUNNER
+#!/usr/bin/env zsh
+set -euo pipefail
+set -a
+source "$RELAY_HOME/env"
+set +a
+export PYTHONPATH="$RELAY_HOME/src"
+exec /usr/bin/python3 -m litellm_relay.cli serve
+RUNNER
+chmod 700 "$RELAY_HOME/bin/run-relay"
+
+cat > "$RELAY_HOME/relay.pac" <<PAC
+function FindProxyForURL(url, host) {
+  var relayProxy = "PROXY 127.0.0.1:$RELAY_PORT";
+  var notionDomains = ["notion.so", "notion.com", "api.notion.com", "www.notion.so", "app.notion.com"];
+  host = host.toLowerCase();
+  for (var i = 0; i < notionDomains.length; i++) {
+    var domain = notionDomains[i];
+    if (host === domain || dnsDomainIs(host, "." + domain)) {
+      return relayProxy;
+    }
+  }
+  return "DIRECT";
+}
+PAC
+
+PLIST="$HOME/Library/LaunchAgents/ai.litellm.relay.plist"
+mkdir -p "$(dirname "$PLIST")"
+cat > "$PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.litellm.relay</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$RELAY_HOME/bin/run-relay</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$RELAY_HOME/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$RELAY_HOME/launchd.err.log</string>
+</dict>
+</plist>
+PLIST
+
+launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1 || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+launchctl enable "gui/$(id -u)/ai.litellm.relay"
+
+if [[ -n "$NETWORK_SERVICE" ]]; then
+  networksetup -setautoproxyurl "$NETWORK_SERVICE" "http://127.0.0.1:$RELAY_PORT/proxy.pac"
+  networksetup -setautoproxystate "$NETWORK_SERVICE" on
+fi
+
+cat <<DONE
+LiteLLM Relay installed.
+
+Relay proxy: 127.0.0.1:$RELAY_PORT
+PAC URL:     http://127.0.0.1:$RELAY_PORT/proxy.pac
+Logs:        $RELAY_HOME/relay.log.jsonl
+
+To route Notion through Relay for a manual pilot:
+  networksetup -setautoproxyurl "Wi-Fi" http://127.0.0.1:$RELAY_PORT/proxy.pac
+  networksetup -setautoproxystate "Wi-Fi" on
+
+To enable shadow calls through LiteLLM Gateway, set LITELLM_GATEWAY_API_KEY and
+LITELLM_RELAY_SHADOW_ENABLED=1 before running install.sh, then restart Relay.
+DONE

--- a/mdm/litellm-relay-pac.mobileconfig.example
+++ b/mdm/litellm-relay-pac.mobileconfig.example
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadType</key>
+      <string>com.apple.SystemConfiguration</string>
+      <key>PayloadIdentifier</key>
+      <string>ai.litellm.relay.proxy</string>
+      <key>PayloadUUID</key>
+      <string>00000000-0000-4000-8000-000000000001</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>ProxyAutoConfigEnable</key>
+      <integer>1</integer>
+      <key>ProxyAutoConfigURLString</key>
+      <string>http://127.0.0.1:4142/proxy.pac</string>
+    </dict>
+  </array>
+  <key>PayloadDisplayName</key>
+  <string>LiteLLM Relay PAC</string>
+  <key>PayloadIdentifier</key>
+  <string>ai.litellm.relay</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>00000000-0000-4000-8000-000000000000</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "litellm-relay"
+version = "0.1.0"
+description = "Local endpoint relay for shadowing and routing AI app traffic through LiteLLM Gateway."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "LiteLLM" }]
+dependencies = []
+
+[project.scripts]
+litellm-relay = "litellm_relay.cli:main"

--- a/src/litellm_relay/__init__.py
+++ b/src/litellm_relay/__init__.py
@@ -1,0 +1,4 @@
+"""LiteLLM Relay local agent."""
+
+__version__ = "0.1.0"
+

--- a/src/litellm_relay/cli.py
+++ b/src/litellm_relay/cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from .config import RelayConfig
+from .pac import build_pac
+from .proxy import RelayProxy
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="litellm-relay")
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("serve", help="Run the local Relay proxy")
+    subparsers.add_parser("pac", help="Print the PAC file served by Relay")
+    args = parser.parse_args(argv)
+
+    config = RelayConfig.from_env()
+    if args.command == "pac":
+        sys.stdout.write(build_pac(config))
+        return 0
+    if args.command in {None, "serve"}:
+        try:
+            asyncio.run(RelayProxy(config).serve_forever())
+        except KeyboardInterrupt:
+            return 130
+        return 0
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/litellm_relay/config.py
+++ b/src/litellm_relay/config.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import os
+
+
+DEFAULT_NOTION_DOMAINS = (
+    "notion.so",
+    "notion.com",
+    "api.notion.com",
+    "www.notion.so",
+    "app.notion.com",
+)
+
+
+@dataclass(frozen=True)
+class RelayConfig:
+    host: str = "127.0.0.1"
+    port: int = 4142
+    log_path: Path = Path.home() / ".litellm-relay" / "relay.log.jsonl"
+    notion_domains: tuple[str, ...] = DEFAULT_NOTION_DOMAINS
+    shadow_enabled: bool = False
+    gateway_url: str = "http://127.0.0.1:4000"
+    gateway_api_key: str | None = None
+    shadow_model: str = "gpt-4o-mini"
+    shadow_min_interval_seconds: int = 60
+    request_timeout_seconds: float = 10.0
+    extra_headers: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls) -> "RelayConfig":
+        domains = os.getenv("LITELLM_RELAY_NOTION_DOMAINS")
+        parsed_domains = (
+            tuple(d.strip().lower() for d in domains.split(",") if d.strip())
+            if domains
+            else DEFAULT_NOTION_DOMAINS
+        )
+        return cls(
+            host=os.getenv("LITELLM_RELAY_HOST", "127.0.0.1"),
+            port=int(os.getenv("LITELLM_RELAY_PORT", "4142")),
+            log_path=Path(
+                os.getenv(
+                    "LITELLM_RELAY_LOG_PATH",
+                    str(Path.home() / ".litellm-relay" / "relay.log.jsonl"),
+                )
+            ),
+            notion_domains=parsed_domains,
+            shadow_enabled=os.getenv("LITELLM_RELAY_SHADOW_ENABLED", "").lower()
+            in {"1", "true", "yes", "on"},
+            gateway_url=os.getenv("LITELLM_GATEWAY_URL", "http://127.0.0.1:4000"),
+            gateway_api_key=os.getenv("LITELLM_GATEWAY_API_KEY"),
+            shadow_model=os.getenv("LITELLM_RELAY_SHADOW_MODEL", "gpt-4o-mini"),
+            shadow_min_interval_seconds=int(
+                os.getenv("LITELLM_RELAY_SHADOW_MIN_INTERVAL_SECONDS", "60")
+            ),
+            request_timeout_seconds=float(
+                os.getenv("LITELLM_RELAY_REQUEST_TIMEOUT_SECONDS", "10")
+            ),
+        )
+
+
+def normalize_host(host: str) -> str:
+    host = host.strip().lower()
+    if host.startswith("["):
+        return host.split("]", 1)[0].strip("[]")
+    return host.split(":", 1)[0]
+
+
+def is_domain_match(host: str, domains: tuple[str, ...]) -> bool:
+    normalized = normalize_host(host)
+    return any(normalized == domain or normalized.endswith(f".{domain}") for domain in domains)
+
+
+def is_notion_host(host: str, config: RelayConfig) -> bool:
+    return is_domain_match(host, config.notion_domains)
+

--- a/src/litellm_relay/pac.py
+++ b/src/litellm_relay/pac.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from .config import RelayConfig
+
+
+def build_pac(config: RelayConfig) -> str:
+    domains = ",\n    ".join(f'"{domain}"' for domain in config.notion_domains)
+    return f"""function FindProxyForURL(url, host) {{
+  var relayProxy = "PROXY {config.host}:{config.port}";
+  var notionDomains = [
+    {domains}
+  ];
+
+  host = host.toLowerCase();
+  for (var i = 0; i < notionDomains.length; i++) {{
+    var domain = notionDomains[i];
+    if (host === domain || dnsDomainIs(host, "." + domain)) {{
+      return relayProxy;
+    }}
+  }}
+
+  return "DIRECT";
+}}
+"""
+

--- a/src/litellm_relay/proxy.py
+++ b/src/litellm_relay/proxy.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+import json
+from uuid import uuid4
+
+from .config import RelayConfig, is_notion_host, normalize_host
+from .pac import build_pac
+from .shadow import ShadowClient
+
+
+class RelayProxy:
+    def __init__(self, config: RelayConfig):
+        self.config = config
+        self.shadow_client = ShadowClient(config)
+
+    async def serve_forever(self) -> None:
+        self.config.log_path.parent.mkdir(parents=True, exist_ok=True)
+        server = await asyncio.start_server(
+            self._handle_client, self.config.host, self.config.port
+        )
+        self._log(
+            {
+                "event": "relay_started",
+                "listen": f"{self.config.host}:{self.config.port}",
+                "shadow_enabled": self.config.shadow_enabled,
+            }
+        )
+        async with server:
+            await server.serve_forever()
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        peer = writer.get_extra_info("peername")
+        try:
+            header = await reader.readuntil(b"\r\n\r\n")
+        except asyncio.IncompleteReadError:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        try:
+            header_text = header.decode("iso-8859-1")
+            request_line = header_text.splitlines()[0]
+            method, target, _version = request_line.split(" ", 2)
+        except (UnicodeDecodeError, ValueError, IndexError):
+            await self._write_response(writer, 400, b"bad request\n")
+            return
+
+        if method.upper() == "GET" and target in {"/proxy.pac", "/pac"}:
+            pac = build_pac(self.config).encode("utf-8")
+            await self._write_response(
+                writer, 200, pac, content_type="application/x-ns-proxy-autoconfig"
+            )
+            return
+
+        if method.upper() == "CONNECT":
+            await self._handle_connect(target, peer, reader, writer)
+            return
+
+        await self._write_response(
+            writer,
+            501,
+            b"litellm-relay v0 only supports CONNECT tunneling and /proxy.pac\n",
+        )
+
+    async def _handle_connect(
+        self,
+        target: str,
+        peer: object,
+        client_reader: asyncio.StreamReader,
+        client_writer: asyncio.StreamWriter,
+    ) -> None:
+        host, port = parse_connect_target(target)
+        event = self._event(
+            {
+                "event": "connect",
+                "method": "CONNECT",
+                "host": host,
+                "port": port,
+                "peer": repr(peer),
+                "notion_match": is_notion_host(host, self.config),
+            }
+        )
+
+        if event["notion_match"]:
+            shadow_result = self.shadow_client.maybe_shadow(event)
+            event["shadow"] = {
+                "attempted": shadow_result.attempted,
+                "ok": shadow_result.ok,
+                "status": shadow_result.status,
+                "error": shadow_result.error,
+                "event_id": shadow_result.event_id,
+            }
+        self._log(event)
+
+        try:
+            upstream_reader, upstream_writer = await asyncio.open_connection(host, port)
+        except OSError as exc:
+            self._log(
+                self._event(
+                    {
+                        "event": "connect_failed",
+                        "host": host,
+                        "port": port,
+                        "error": exc.__class__.__name__,
+                    }
+                )
+            )
+            await self._write_response(client_writer, 502, b"upstream connect failed\n")
+            return
+
+        client_writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        await client_writer.drain()
+        await tunnel(client_reader, client_writer, upstream_reader, upstream_writer)
+
+    async def _write_response(
+        self,
+        writer: asyncio.StreamWriter,
+        status: int,
+        body: bytes,
+        content_type: str = "text/plain",
+    ) -> None:
+        reason = {
+            200: "OK",
+            400: "Bad Request",
+            501: "Not Implemented",
+            502: "Bad Gateway",
+        }.get(status, "OK")
+        writer.write(
+            (
+                f"HTTP/1.1 {status} {reason}\r\n"
+                f"content-length: {len(body)}\r\n"
+                f"content-type: {content_type}\r\n"
+                "connection: close\r\n"
+                "\r\n"
+            ).encode("ascii")
+            + body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    def _event(self, values: dict[str, object]) -> dict[str, object]:
+        return {
+            "event_id": str(uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **values,
+        }
+
+    def _log(self, event: dict[str, object]) -> None:
+        self.config.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.config.log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(json.dumps(redact_event(event), sort_keys=True) + "\n")
+
+
+async def tunnel(
+    client_reader: asyncio.StreamReader,
+    client_writer: asyncio.StreamWriter,
+    upstream_reader: asyncio.StreamReader,
+    upstream_writer: asyncio.StreamWriter,
+) -> None:
+    async def pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while chunk := await reader.read(65536):
+                writer.write(chunk)
+                await writer.drain()
+        except (ConnectionError, asyncio.CancelledError):
+            pass
+        finally:
+            writer.close()
+
+    await asyncio.gather(
+        pipe(client_reader, upstream_writer),
+        pipe(upstream_reader, client_writer),
+        return_exceptions=True,
+    )
+
+
+def parse_connect_target(target: str) -> tuple[str, int]:
+    if target.startswith("["):
+        host, _, rest = target[1:].partition("]")
+        port = int(rest.lstrip(":") or "443")
+        return host, port
+    host, sep, port = target.partition(":")
+    return normalize_host(host), int(port) if sep else 443
+
+
+def redact_event(event: dict[str, object]) -> dict[str, object]:
+    redacted = dict(event)
+    for key in ("authorization", "cookie", "token_v2", "prompt", "body", "url"):
+        redacted.pop(key, None)
+    return redacted

--- a/src/litellm_relay/shadow.py
+++ b/src/litellm_relay/shadow.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+import time
+import urllib.error
+import urllib.request
+from uuid import uuid4
+
+from .config import RelayConfig
+
+
+@dataclass(frozen=True)
+class ShadowResult:
+    attempted: bool
+    ok: bool
+    status: int | None = None
+    error: str | None = None
+    event_id: str | None = None
+
+
+class ShadowClient:
+    def __init__(self, config: RelayConfig):
+        self.config = config
+        self._last_shadow_by_host: dict[str, float] = {}
+
+    def maybe_shadow(self, event: dict[str, object]) -> ShadowResult:
+        if not self.config.shadow_enabled:
+            return ShadowResult(attempted=False, ok=False)
+        if not self.config.gateway_api_key:
+            return ShadowResult(
+                attempted=False,
+                ok=False,
+                error="LITELLM_GATEWAY_API_KEY is not set",
+            )
+
+        host = str(event.get("host", "unknown"))
+        now = time.monotonic()
+        last_shadow = self._last_shadow_by_host.get(host, 0)
+        if now - last_shadow < self.config.shadow_min_interval_seconds:
+            return ShadowResult(attempted=False, ok=False, error="throttled")
+
+        self._last_shadow_by_host[host] = now
+        event_id = str(event.get("event_id") or uuid4())
+        payload = build_shadow_payload(event, self.config, event_id)
+        request = urllib.request.Request(
+            url=f"{self.config.gateway_url.rstrip('/')}/v1/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "authorization": f"Bearer {self.config.gateway_api_key}",
+                "content-type": "application/json",
+                **self.config.extra_headers,
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(
+                request, timeout=self.config.request_timeout_seconds
+            ) as response:
+                return ShadowResult(
+                    attempted=True,
+                    ok=200 <= response.status < 300,
+                    status=response.status,
+                    event_id=event_id,
+                )
+        except urllib.error.HTTPError as exc:
+            return ShadowResult(
+                attempted=True,
+                ok=False,
+                status=exc.code,
+                error=f"gateway_http_{exc.code}",
+                event_id=event_id,
+            )
+        except OSError as exc:
+            return ShadowResult(
+                attempted=True,
+                ok=False,
+                error=exc.__class__.__name__,
+                event_id=event_id,
+            )
+
+
+def build_shadow_payload(
+    event: dict[str, object], config: RelayConfig, event_id: str
+) -> dict[str, object]:
+    host = str(event.get("host", "unknown"))
+    host_hash = sha256(host.encode("utf-8")).hexdigest()
+    timestamp = str(event.get("timestamp") or datetime.now(timezone.utc).isoformat())
+    return {
+        "model": config.shadow_model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You confirm receipt of redacted LiteLLM Relay shadow events.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Return exactly OK. "
+                    f"source=notion-mac method={event.get('method', 'CONNECT')} "
+                    f"event_id={event_id} host_hash={host_hash[:16]}"
+                ),
+            },
+        ],
+        "metadata": {
+            "source": "litellm-relay",
+            "shadow_source": "notion-mac",
+            "event_id": event_id,
+            "host_hash": host_hash,
+            "method": str(event.get("method", "CONNECT")),
+            "timestamp": timestamp,
+        },
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import unittest
+
+from litellm_relay.config import RelayConfig, is_notion_host, normalize_host
+
+
+class ConfigTests(unittest.TestCase):
+    def test_normalize_host_strips_port(self):
+        self.assertEqual(normalize_host("www.notion.so:443"), "www.notion.so")
+
+
+    def test_is_notion_host_matches_subdomains(self):
+        config = RelayConfig()
+        self.assertTrue(is_notion_host("www.notion.so:443", config))
+        self.assertTrue(is_notion_host("app.notion.com", config))
+        self.assertFalse(is_notion_host("example.com", config))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pac.py
+++ b/tests/test_pac.py
@@ -1,0 +1,16 @@
+import unittest
+
+from litellm_relay.config import RelayConfig
+from litellm_relay.pac import build_pac
+
+
+class PacTests(unittest.TestCase):
+    def test_build_pac_routes_only_notion_domains(self):
+        pac = build_pac(RelayConfig(port=4142))
+        self.assertIn("PROXY 127.0.0.1:4142", pac)
+        self.assertIn('"notion.so"', pac)
+        self.assertIn('return "DIRECT"', pac)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,32 @@
+import unittest
+
+from litellm_relay.proxy import parse_connect_target, redact_event
+
+
+class ProxyTests(unittest.TestCase):
+    def test_parse_connect_target_defaults_to_tls_port(self):
+        self.assertEqual(parse_connect_target("www.notion.so"), ("www.notion.so", 443))
+
+
+    def test_parse_connect_target_reads_port(self):
+        self.assertEqual(parse_connect_target("www.notion.so:443"), ("www.notion.so", 443))
+
+
+    def test_redact_event_drops_sensitive_fields(self):
+        redacted = redact_event(
+            {
+                "event": "connect",
+                "host": "www.notion.so",
+                "cookie": "token_v2=secret",
+                "authorization": "Bearer secret",
+                "body": "prompt",
+            }
+        )
+        self.assertNotIn("cookie", redacted)
+        self.assertNotIn("authorization", redacted)
+        self.assertNotIn("body", redacted)
+        self.assertEqual(redacted["host"], "www.notion.so")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,23 @@
+import unittest
+
+from litellm_relay.config import RelayConfig
+from litellm_relay.shadow import build_shadow_payload
+
+
+class ShadowTests(unittest.TestCase):
+    def test_shadow_payload_excludes_raw_host_and_uses_hash(self):
+        payload = build_shadow_payload(
+            {"host": "www.notion.so", "method": "CONNECT"},
+            RelayConfig(shadow_model="test-model"),
+            "event-1",
+        )
+
+        serialized = str(payload)
+        self.assertEqual(payload["model"], "test-model")
+        self.assertEqual(payload["metadata"]["event_id"], "event-1")
+        self.assertNotIn("www.notion.so", serialized)
+        self.assertIn("host_hash", payload["metadata"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLIST="$HOME/Library/LaunchAgents/ai.litellm.relay.plist"
+RELAY_HOME="${RELAY_HOME:-$HOME/.litellm-relay}"
+
+launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1 || true
+rm -f "$PLIST"
+
+cat <<DONE
+LiteLLM Relay LaunchAgent removed.
+
+Relay data remains at:
+  $RELAY_HOME
+
+If you enabled a system PAC manually, disable it with:
+  networksetup -setautoproxystate "Wi-Fi" off
+DONE
+


### PR DESCRIPTION
## Summary
- add a stdlib Python Relay proxy that serves a PAC file and tunnels HTTPS CONNECT traffic
- add Notion domain matching, redacted JSONL metadata logs, and optional synthetic shadow calls to LiteLLM Gateway
- add macOS install/uninstall scripts, MDM rollout notes, PAC mobileconfig example, OSS license, and CI

## Notion shadowing scope
V0 shadows Notion traffic at the proxy metadata layer: host, port, timestamp, event id, and shadow status. It does not decrypt TLS, capture prompts/cookies/page content, or rewrite Notion private APIs.

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- PYTHONPATH=src python3 -m compileall -q src tests
- PYTHONPATH=src python3 -m litellm_relay.cli pac
- bash -n install.sh && bash -n uninstall.sh
- runtime smoke: served PAC on a temp port and proxied a single CONNECT to https://www.notion.so
- shadow smoke: proxied a Notion CONNECT with LITELLM_RELAY_SHADOW_ENABLED=1 to a fake local Gateway and verified only hashed/redacted metadata was sent