### PR TITLE
Add local Relay dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ deployment for Notion Mac app traffic.
 ## V0 scope
 
 - Starts a local HTTP CONNECT proxy on `127.0.0.1:4142`.
+- Serves a local dashboard at `http://127.0.0.1:4142/`.
 - Serves a PAC file at `http://127.0.0.1:4142/proxy.pac`.
-- Routes Notion domains through Relay when the PAC is installed.
-- Logs redacted Notion connection metadata to `~/.litellm-relay/relay.log.jsonl`.
+- Routes known AI domains through Relay when the PAC is installed.
+- Logs redacted AI connection metadata to `~/.litellm-relay/relay.log.jsonl`.
 - Optionally sends a synthetic shadow event through LiteLLM Gateway for audit correlation.
 
 V0 does **not** decrypt TLS, capture Notion prompts, capture cookies, or rewrite
@@ -27,6 +28,24 @@ To immediately route Notion traffic on a pilot Mac:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh \
   | bash -s -- --set-system-proxy "Wi-Fi"
+```
+
+Open the dashboard:
+
+```bash
+open http://127.0.0.1:4142/
+```
+
+Generate a test intercepted request:
+
+```bash
+curl -I -x http://127.0.0.1:4142 https://www.notion.so
+```
+
+Generate a Codex/OpenAI-style intercepted request:
+
+```bash
+curl -I -x http://127.0.0.1:4142 https://api.openai.com/v1/models
 ```
 
 To enable Gateway shadow calls:

--- a/docs/mdm.md
+++ b/docs/mdm.md
@@ -16,6 +16,12 @@ curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.
   | bash -s -- --set-system-proxy "Wi-Fi"
 ```
 
+The installed dashboard is served locally at:
+
+```text
+http://127.0.0.1:4142/
+```
+
 ## Jamf
 
 1. Package this repo as a signed macOS package.
@@ -45,4 +51,3 @@ curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.
 macOS has a single Global HTTP Proxy payload per device. Customers already using
 a corporate proxy need a coordinated PAC file instead of a second competing
 profile.
-

--- a/docs/notion-shadow-v0.md
+++ b/docs/notion-shadow-v0.md
@@ -29,6 +29,7 @@ Trigger Notion AI in the Notion Mac app, then inspect:
 
 ```bash
 tail -f ~/.litellm-relay/relay.log.jsonl
+open http://127.0.0.1:4142/
 ```
 
 Expected redacted event:
@@ -46,6 +47,13 @@ Expected redacted event:
     "status": 200
   }
 }
+```
+
+You can generate a test row without changing system proxy settings:
+
+```bash
+curl -I -x http://127.0.0.1:4142 https://www.notion.so
+curl -I -x http://127.0.0.1:4142 https://api.openai.com/v1/models
 ```
 
 ## Why this is not MITM

--- a/index.html
+++ b/index.html
@@ -1,790 +1,230 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>LiteLLM Relay | V0 Scope</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LiteLLM Relay</title>
   <style>
     :root {
-      --ink: #17202f;
-      --muted: #5f6b7a;
-      --line: #dce5e2;
-      --panel: #f7faf9;
-      --soft: #edf4f2;
-      --teal: #34c6a3;
-      --teal-dark: #14866f;
-      --amber: #cf8d35;
-      --plum: #6d5cae;
-      --white: #ffffff;
-      --code: #10231f;
+      --background: 240 10% 3.9%;
+      --foreground: 0 0% 98%;
+      --card: 240 10% 3.9%;
+      --muted-foreground: 240 5% 64.9%;
+      --border: 240 3.7% 15.9%;
+      --primary: 162 74% 45%;
+      --primary-foreground: 164 95% 8%;
+      --secondary: 240 3.7% 15.9%;
+      --radius: 0.625rem;
+      --font-sans: "Geist", "Geist Fallback", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-mono: "Geist Mono", "Geist Mono Fallback", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     }
 
-    * {
-      box-sizing: border-box;
-    }
+    * { box-sizing: border-box; }
 
     body {
       margin: 0;
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      color: var(--ink);
-      background: #ffffff;
-      line-height: 1.55;
-    }
-
-    a {
-      color: var(--teal-dark);
-      text-decoration: none;
-    }
-
-    a:hover {
-      text-decoration: underline;
-    }
-
-    .hero {
-      min-height: 76vh;
-      display: grid;
-      grid-template-rows: auto 1fr;
-      background:
-        linear-gradient(90deg, rgba(255,255,255,0.98) 0%, rgba(255,255,255,0.88) 43%, rgba(255,255,255,0.28) 100%),
-        url("assets/relay-hero.png") center right / cover no-repeat;
-      border-bottom: 1px solid var(--line);
-    }
-
-    .topbar {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 24px clamp(22px, 5vw, 72px);
-      gap: 20px;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      font-weight: 760;
+      min-height: 100vh;
+      background: hsl(var(--background));
+      color: hsl(var(--foreground));
+      font-family: var(--font-sans);
       letter-spacing: 0;
     }
 
-    .mark {
-      width: 28px;
-      height: 28px;
-      border: 2px solid var(--teal);
-      position: relative;
-    }
-
-    .mark::before,
-    .mark::after {
-      content: "";
-      position: absolute;
-      background: var(--teal);
-      left: 5px;
-      right: 5px;
-      height: 2px;
-      top: 12px;
-    }
-
-    .mark::after {
-      transform: rotate(90deg);
-    }
-
-    .nav {
-      display: flex;
-      gap: 18px;
-      color: var(--muted);
-      font-size: 14px;
-    }
-
-    .hero-inner {
-      width: min(1180px, calc(100% - 44px));
+    main {
+      width: min(1120px, calc(100% - 40px));
+      min-height: 100vh;
       margin: 0 auto;
       display: grid;
       align-items: center;
-      padding: 28px 0 34px;
+      padding: 48px 0;
     }
 
-    .hero-copy {
-      width: min(690px, 100%);
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(0, 0.92fr) minmax(360px, 0.68fr);
+      gap: 22px;
+      align-items: stretch;
+    }
+
+    .hero, .card {
+      border: 1px solid hsl(var(--border));
+      border-radius: var(--radius);
+      background: hsl(var(--card));
+      box-shadow: 0 1px 2px hsl(0 0% 0% / 0.18);
+    }
+
+    .hero {
+      padding: clamp(28px, 5vw, 54px);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 40px;
+      min-height: 560px;
     }
 
     .eyebrow {
       display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      color: var(--teal-dark);
+      width: fit-content;
+      border: 1px solid hsl(var(--border));
+      border-radius: 999px;
+      padding: 6px 10px;
+      color: hsl(var(--muted-foreground));
       font-size: 13px;
-      font-weight: 720;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: 18px;
-    }
-
-    .eyebrow::before {
-      content: "";
-      width: 34px;
-      height: 2px;
-      background: var(--teal);
-    }
-
-    h1, h2, h3 {
-      margin: 0;
-      line-height: 1.08;
-      letter-spacing: 0;
+      font-weight: 650;
+      background: hsl(var(--secondary));
     }
 
     h1 {
-      font-size: clamp(42px, 6.2vw, 76px);
-      max-width: 880px;
+      margin: 22px 0 0;
+      max-width: 720px;
+      font-size: clamp(42px, 6vw, 74px);
+      line-height: 1.02;
+      letter-spacing: 0;
     }
 
-    .subhead {
-      margin-top: 20px;
-      color: #384657;
-      font-size: clamp(19px, 2vw, 27px);
-      max-width: 760px;
+    .lead {
+      max-width: 680px;
+      margin: 22px 0 0;
+      color: hsl(var(--muted-foreground));
+      font-size: 18px;
+      line-height: 1.7;
     }
 
-    .hero-actions {
+    .actions {
       display: flex;
       flex-wrap: wrap;
-      gap: 12px;
-      margin-top: 26px;
+      gap: 10px;
+      margin-top: 30px;
     }
 
     .button {
+      min-height: 40px;
+      border-radius: calc(var(--radius) - 2px);
+      border: 1px solid hsl(var(--border));
+      padding: 0 14px;
+      background: hsl(var(--secondary));
+      color: hsl(var(--foreground));
+      text-decoration: none;
       display: inline-flex;
       align-items: center;
-      justify-content: center;
-      min-height: 44px;
-      padding: 0 18px;
-      border-radius: 6px;
-      border: 1px solid var(--ink);
-      color: var(--white);
-      background: var(--ink);
-      font-weight: 720;
-      font-size: 14px;
+      font-weight: 650;
     }
 
-    .button.secondary {
-      color: var(--ink);
-      background: rgba(255,255,255,0.82);
-      border-color: var(--line);
+    .button.primary {
+      background: hsl(var(--primary));
+      border-color: hsl(var(--primary));
+      color: hsl(var(--primary-foreground));
     }
 
-    .section {
-      padding: 74px clamp(22px, 5vw, 72px);
-      border-bottom: 1px solid var(--line);
-    }
-
-    .section.alt {
-      background: var(--panel);
-    }
-
-    .section-inner {
-      width: min(1180px, 100%);
-      margin: 0 auto;
-    }
-
-    .section-title {
-      display: grid;
-      grid-template-columns: minmax(0, 0.74fr) minmax(280px, 0.55fr);
-      gap: 42px;
-      align-items: end;
-      margin-bottom: 34px;
-    }
-
-    h2 {
-      font-size: clamp(32px, 4.3vw, 58px);
-    }
-
-    .section-title p {
-      color: var(--muted);
-      margin: 0;
-      font-size: 18px;
-    }
-
-    .grid-3 {
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 18px;
-    }
-
-    .grid-2 {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 18px;
-    }
-
-    .tile {
-      border: 1px solid var(--line);
-      background: var(--white);
-      padding: 24px;
-      border-radius: 8px;
-      min-height: 180px;
-    }
-
-    .tile h3 {
-      font-size: 21px;
-      margin-bottom: 10px;
-    }
-
-    .tile p,
-    .tile li {
-      color: var(--muted);
-      margin: 0;
-    }
-
-    .tile ul {
-      margin: 14px 0 0;
-      padding-left: 18px;
-    }
-
-    .tag {
-      display: inline-flex;
-      padding: 4px 8px;
-      margin-bottom: 14px;
-      border-radius: 5px;
-      background: var(--soft);
-      color: var(--teal-dark);
-      font-size: 12px;
-      font-weight: 760;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-    }
-
-    .architecture {
-      background: var(--code);
-      color: #d9fff5;
-      border-radius: 8px;
-      padding: clamp(24px, 4vw, 42px);
+    .code {
+      border: 1px solid hsl(var(--border));
+      border-radius: calc(var(--radius) - 2px);
+      background: hsl(240 10% 6%);
+      padding: 14px;
+      color: hsl(var(--muted-foreground));
+      font: 13px/1.7 var(--font-mono);
       overflow-x: auto;
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
     }
 
-    .architecture pre {
-      margin: 0;
-      font: 15px/1.75 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      white-space: pre;
-    }
-
-    .architecture .muted {
-      color: #80b0a4;
-    }
-
-    .architecture .accent {
-      color: #62e6c7;
-    }
-
-    .proof {
-      display: grid;
-      grid-template-columns: minmax(280px, 0.62fr) minmax(0, 1fr);
-      gap: 24px;
-      align-items: stretch;
-    }
-
-    .evidence {
-      background: #101820;
-      color: #e5fff8;
-      border-radius: 8px;
+    .card {
       padding: 22px;
-      overflow-x: auto;
-    }
-
-    .evidence pre {
-      margin: 0;
-      font: 13px/1.7 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      white-space: pre-wrap;
-    }
-
-    .timeline {
       display: grid;
-      gap: 14px;
+      gap: 16px;
+      align-content: start;
+    }
+
+    .card h2 {
+      margin: 0;
+      font-size: 20px;
+      line-height: 1.2;
+    }
+
+    .card p {
+      margin: 0;
+      color: hsl(var(--muted-foreground));
+      line-height: 1.6;
+    }
+
+    .steps {
+      display: grid;
+      gap: 10px;
     }
 
     .step {
       display: grid;
-      grid-template-columns: 64px minmax(0, 1fr);
-      gap: 18px;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: var(--white);
-      padding: 18px;
+      grid-template-columns: 34px minmax(0, 1fr);
+      gap: 12px;
+      align-items: start;
     }
 
     .num {
-      color: var(--teal-dark);
-      font: 700 16px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    }
-
-    .step h3 {
-      font-size: 20px;
-      margin-bottom: 7px;
-    }
-
-    .step p {
-      margin: 0;
-      color: var(--muted);
-    }
-
-    .matrix {
-      width: 100%;
-      border-collapse: collapse;
-      background: var(--white);
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      overflow: hidden;
-      display: table;
-    }
-
-    .matrix th,
-    .matrix td {
-      text-align: left;
-      vertical-align: top;
-      padding: 16px;
-      border-bottom: 1px solid var(--line);
-    }
-
-    .matrix th {
-      font-size: 13px;
-      color: var(--muted);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      background: var(--soft);
-    }
-
-    .matrix tr:last-child td {
-      border-bottom: 0;
-    }
-
-    .status {
-      font-weight: 780;
-      color: var(--ink);
-    }
-
-    .status.good {
-      color: var(--teal-dark);
-    }
-
-    .status.warn {
-      color: var(--amber);
-    }
-
-    .status.future {
-      color: var(--plum);
-    }
-
-    .repo-list {
+      width: 28px;
+      height: 28px;
+      border-radius: 999px;
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 10px;
-      margin-top: 18px;
+      place-items: center;
+      background: hsl(var(--secondary));
+      color: hsl(var(--muted-foreground));
+      font: 700 12px/1 var(--font-mono);
     }
 
-    .path {
-      font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      background: var(--soft);
-      border: 1px solid var(--line);
-      border-radius: 6px;
-      padding: 12px;
-      color: #25413a;
-    }
-
-    .source-list {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 12px;
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .source-list li {
-      border-top: 1px solid var(--line);
-      padding-top: 12px;
-      color: var(--muted);
-      font-size: 14px;
-    }
-
-    footer {
-      padding: 34px clamp(22px, 5vw, 72px);
-      color: var(--muted);
-      font-size: 14px;
-    }
-
-    @media (max-width: 860px) {
-      .hero {
-        min-height: auto;
-        background:
-          linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(255,255,255,0.86) 100%),
-          url("assets/relay-hero.png") center / cover no-repeat;
-      }
-
-      .nav {
-        display: none;
-      }
-
-      .section-title,
-      .grid-3,
-      .grid-2,
-      .proof,
-      .repo-list,
-      .source-list {
-        grid-template-columns: 1fr;
-      }
-
-      .matrix {
-        display: block;
-        overflow-x: auto;
-      }
+    @media (max-width: 900px) {
+      .layout { grid-template-columns: 1fr; }
+      .hero { min-height: auto; }
     }
   </style>
 </head>
 <body>
-  <header class="hero">
-    <div class="topbar">
-      <div class="brand"><span class="mark"></span><span>LiteLLM Relay</span></div>
-      <nav class="nav" aria-label="Page sections">
-        <a href="#scope">Scope</a>
-        <a href="#notion">Notion AI proof</a>
-        <a href="#repo">Repo</a>
-        <a href="#names">Names</a>
-      </nav>
-    </div>
-    <div class="hero-inner">
-      <div class="hero-copy">
-        <div class="eyebrow">V0 product scope</div>
-        <h1>Bring every employee AI tool back through LiteLLM Gateway.</h1>
-        <p class="subhead">
-          LiteLLM Relay is a machine-installed agent that routes supported desktop apps,
-          browser AI, coding tools, and MCP servers through the LiteLLM Gateway already
-          trusted for governance, budgets, guardrails, and observability.
-        </p>
-        <div class="hero-actions">
-          <a class="button" href="#notion">Review Notion AI path</a>
-          <a class="button secondary" href="#repo">Open repo scope</a>
-        </div>
-      </div>
-    </div>
-  </header>
-
   <main>
-    <section id="scope" class="section">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>The wedge is routing first, transparent capture second.</h2>
-          <p>
-            Do not promise perfect interception on day one. V0 wins by routing tools with
-            base URL or proxy support, discovering shadow AI, and graduating high-value
-            proprietary apps into managed capture.
+    <div class="layout">
+      <section class="hero">
+        <div>
+          <span class="eyebrow">LiteLLM Relay</span>
+          <h1>Install a local proxy that shows intercepted AI traffic.</h1>
+          <p class="lead">
+            Relay runs on your machine, serves a PAC file, tunnels HTTPS traffic,
+            and exposes a local shadcn-style dashboard at
+            <code>http://127.0.0.1:4142/</code>.
           </p>
-        </div>
-        <div class="grid-3">
-          <article class="tile">
-            <span class="tag">Route</span>
-            <h3>Supported tools use local endpoints</h3>
-            <p>Expose OpenAI-compatible and Anthropic-compatible local endpoints, then forward through LiteLLM Gateway with device and team metadata.</p>
-            <ul>
-              <li>Codex-style OpenAI clients</li>
-              <li>Claude Code and Anthropic-compatible CLIs</li>
-              <li>Aider, Continue, OpenCode, custom SDK apps</li>
-            </ul>
-          </article>
-          <article class="tile">
-            <span class="tag">Discover</span>
-            <h3>Shadow AI and MCP inventory</h3>
-            <p>Scan app configs, MCP server files, process destinations, and proxy flows so admins can see what tools are active before enforcing policy.</p>
-            <ul>
-              <li>Device app coverage</li>
-              <li>MCP server allowlist</li>
-              <li>Unsupported destination alerts</li>
-            </ul>
-          </article>
-          <article class="tile">
-            <span class="tag">Capture</span>
-            <h3>Managed proxy for proprietary apps</h3>
-            <p>Use PAC/system proxy first. Add MITM and Network Extension only where customers accept the certificate, privacy, and deployment tradeoffs.</p>
-            <ul>
-              <li>macOS PAC profile for V0</li>
-              <li>Root CA only for approved domains</li>
-              <li>Network Extension fallback</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section alt">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>Architecture</h2>
-          <p>
-            A local agent gives us app-specific adapters and a controlled path into the
-            existing Gateway instead of trying to make every private app API look native.
-          </p>
-        </div>
-        <div class="architecture" aria-label="Architecture diagram">
-          <pre><span class="muted">Desktop AI apps | Browser AI | Coding tools | MCP servers</span>
-          |
-          v
-<span class="accent">LiteLLM Relay local agent</span>
-  - 127.0.0.1 OpenAI endpoint:      /v1/chat/completions, /v1/responses
-  - 127.0.0.1 Anthropic endpoint:   /anthropic/v1/messages
-  - HTTP CONNECT proxy:             app-aware routing and telemetry
-  - Adapter workers:                Notion, Copilot, Claude, Cursor, MCP
-  - Policy client:                  signed config from Gateway
-  - Privacy filter:                 redact, hash, and sample before persistence
-          |
-          v
-<span class="accent">LiteLLM Gateway</span>
-  - Virtual keys, teams, budgets, rate limits
-  - Guardrails, logging, spend tracking
-  - Model routing, fallback, approvals
-  - Device and app coverage dashboards</pre>
-        </div>
-      </div>
-    </section>
-
-    <section id="notion" class="section">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>Notion AI: realistic proof path</h2>
-          <p>
-            The Notion Mac app is the right demo because it is a real desktop AI app.
-            The honest V0 proof has two levels: capture metadata today, then decrypt and
-            adapt only on a managed test Mac.
-          </p>
-        </div>
-        <div class="proof">
-          <article class="tile">
-            <span class="tag">Local evidence from this machine</span>
-            <h3>What we proved without installing anything</h3>
-            <p>
-              The Notion Mac app is installed and running as Electron. Its network service
-              process has active HTTPS sockets. The current system has no configured HTTP
-              proxy, so we did not change machine routing or inspect private content.
-            </p>
-            <ul>
-              <li>Process: <strong>Notion Helper --utility-sub-type=network.mojom.NetworkService</strong></li>
-              <li>Observed flow: <strong>Notion PID 853 -> TCP :443</strong></li>
-              <li>System proxy: <strong>disabled</strong></li>
-              <li>App bundle exposes Notion AI shortcut handling and NetLog troubleshooting strings.</li>
-            </ul>
-          </article>
-          <div class="evidence" aria-label="Redacted proof commands">
-            <pre>$ pgrep -afil Notion
-625 /Applications/Notion.app/Contents/MacOS/Notion
-853 Notion Helper --utility-sub-type=network.mojom.NetworkService
-
-$ lsof -nP -iTCP -sTCP:ESTABLISHED | rg Notion
-Notion 853 ... TCP 192.168.x.x:* -> 208.103.161.1:443
-Notion 853 ... TCP 192.168.x.x:* -> 208.103.161.2:443
-
-$ scutil --proxy
-ExceptionsList: *.local, 169.254/16
-No HTTP, HTTPS, SOCKS, or PAC proxy configured</pre>
+          <div class="actions">
+            <a class="button primary" href="http://127.0.0.1:4142/">Open local dashboard</a>
+            <a class="button" href="https://github.com/BerriAI/litellm-relay">GitHub repo</a>
           </div>
         </div>
+        <pre class="code">curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh | bash
 
-        <div style="height: 28px"></div>
+# Manual pilot: route Notion through Relay on Wi-Fi
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/install.sh \
+  | bash -s -- --set-system-proxy "Wi-Fi"</pre>
+      </section>
 
-        <div class="timeline">
+      <aside class="card">
+        <h2>What it does now</h2>
+        <div class="steps">
           <div class="step">
             <div class="num">01</div>
-            <div>
-              <h3>V0 demo: PAC/system proxy capture</h3>
-              <p>
-                Deploy Relay as <code>127.0.0.1:&lt;port&gt;</code>, install a managed PAC profile for
-                <code>*.notion.so</code>, <code>*.notion.com</code>, and <code>api.notion.com</code>, then trigger
-                Notion AI. Success is Notion app traffic arriving at Relay with process,
-                destination, timing, SNI or CONNECT host, and byte counts.
-              </p>
-            </div>
+            <p>Runs a local CONNECT proxy on <code>127.0.0.1:4142</code>.</p>
           </div>
           <div class="step">
             <div class="num">02</div>
-            <div>
-              <h3>Safe shadow-route proof</h3>
-              <p>
-                Use a scratch Notion page and prompt marker such as
-                <code>PROBE-LITELLM-&lt;uuid&gt;</code>. Relay redacts cookies, IDs, URLs, and raw prompt
-                text, then sends a synthetic proof call to LiteLLM Gateway with the same
-                hashed proof ID. This proves Gateway correlation without modifying Notion.
-              </p>
-            </div>
+            <p>Serves a PAC file that routes Notion domains through Relay.</p>
           </div>
           <div class="step">
             <div class="num">03</div>
-            <div>
-              <h3>MITM adapter proof</h3>
-              <p>
-                On a managed test Mac, trust the Relay enterprise CA and capture only
-                approved Notion domains. Look for Notion AI paths such as
-                <code>/api/v3/runInferenceTranscript</code>. Convert the private request into a
-                LiteLLM Gateway call, then synthesize a Notion-compatible response.
-              </p>
-            </div>
+            <p>Logs intercepted host, port, duration, byte counts, and shadow status.</p>
           </div>
           <div class="step">
             <div class="num">04</div>
-            <div>
-              <h3>Production fallback</h3>
-              <p>
-                If the app bypasses system proxy or customers need process-level enforcement,
-                move capture to macOS <code>NETransparentProxyProvider</code>. TLS decryption still
-                requires a trusted CA and explicit customer policy.
-              </p>
-            </div>
+            <p>Shows those events in a local dashboard with filters and raw JSON inspection.</p>
           </div>
         </div>
-      </div>
-    </section>
-
-    <section class="section alt">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>Support matrix</h2>
-          <p>Ship the reliable surfaces first, then use Relay telemetry to decide which proprietary apps deserve adapters.</p>
-        </div>
-        <table class="matrix">
-          <thead>
-            <tr>
-              <th>Surface</th>
-              <th>V0 mode</th>
-              <th>Gateway outcome</th>
-              <th>Risk</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>OpenAI SDKs, Codex-style CLIs, Aider, Continue, OpenCode</td>
-              <td><span class="status good">Direct local endpoint</span></td>
-              <td>Full LiteLLM Gateway routing, budgets, model policy, logs</td>
-              <td>Low. Apps already support custom base URLs.</td>
-            </tr>
-            <tr>
-              <td>Claude Code and Anthropic-compatible tools</td>
-              <td><span class="status good">Anthropic local endpoint</span></td>
-              <td>Translate into Gateway provider calls with team/device metadata</td>
-              <td>Medium. Need strong message-streaming parity.</td>
-            </tr>
-            <tr>
-              <td>GitHub Copilot / IDEs with proxy settings</td>
-              <td><span class="status warn">Configured proxy</span></td>
-              <td>Observe and optionally route where protocol allows</td>
-              <td>Medium. Cert trust and IDE-specific behavior matter.</td>
-            </tr>
-            <tr>
-              <td>Notion AI Mac app</td>
-              <td><span class="status warn">PAC/system proxy first</span></td>
-              <td>Metadata capture, shadow proof, then custom adapter</td>
-              <td>High. Private Notion API can change.</td>
-            </tr>
-            <tr>
-              <td>Browser AI and proprietary desktop apps</td>
-              <td><span class="status future">Transparent capture beta</span></td>
-              <td>Discover, block, or adapt per approved domain</td>
-              <td>High. Privacy, cert pinning, and legal review.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </section>
-
-    <section id="repo" class="section">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>GitHub repo scope</h2>
-          <p>
-            Create the repo as <strong>litellm-relay</strong>. Keep the first PR narrow:
-            local endpoint, policy stub, one adapter, and a Notion proof harness.
-          </p>
-        </div>
-        <div class="grid-2">
-          <article class="tile">
-            <span class="tag">V0 milestones</span>
-            <h3>What ships first</h3>
-            <ul>
-              <li><strong>M0 spike:</strong> local OpenAI endpoint -> LiteLLM Gateway with device metadata.</li>
-              <li><strong>M1 alpha:</strong> macOS daemon, menu bar, policy sync, adapter fixtures.</li>
-              <li><strong>M2 beta:</strong> Windows/Linux service, signed installers, MDM examples.</li>
-              <li><strong>M3 capture:</strong> PAC/system proxy, cert-managed MITM proof, Notion adapter experiment.</li>
-              <li><strong>M4 fleet UI:</strong> Gateway pages for devices, app coverage, MCP inventory, policy rollout.</li>
-            </ul>
-          </article>
-          <article class="tile">
-            <span class="tag">Repository layout</span>
-            <h3>Initial folders</h3>
-            <div class="repo-list">
-              <div class="path">/agent<br>daemon, local endpoints, policy client</div>
-              <div class="path">/proxy<br>CONNECT proxy, PAC, TLS experiments</div>
-              <div class="path">/adapters<br>tool config patchers and app adapters</div>
-              <div class="path">/gateway<br>device, policy, audit API stubs</div>
-              <div class="path">/tray<br>macOS menu bar and diagnostics</div>
-              <div class="path">/installers<br>pkg, MSI, deb/rpm, MDM profiles</div>
-              <div class="path">/proofs/notion<br>redacted Notion AI capture harness</div>
-              <div class="path">/docs<br>security model and support matrix</div>
-            </div>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="names" class="section alt">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>Product names</h2>
-          <p>
-            Recommended: <strong>LiteLLM Relay</strong>. It is clear, ownable, and directly says
-            what the product does without copying competitor language.
-          </p>
-        </div>
-        <div class="grid-3">
-          <article class="tile">
-            <span class="tag">Recommended</span>
-            <h3>LiteLLM Relay</h3>
-            <p>Best balance of enterprise clarity and product polish. Works for “Relay agent,” “Relay policy,” and “Relay fleet.”</p>
-          </article>
-          <article class="tile">
-            <span class="tag">Enterprise clear</span>
-            <h3>LiteLLM Endpoint</h3>
-            <p>Reads like managed endpoint software. Strong for IT buyers, a little less distinctive.</p>
-          </article>
-          <article class="tile">
-            <span class="tag">Developer native</span>
-            <h3>LiteLLM Sidecar</h3>
-            <p>Good for coding tools and local agents, but less intuitive for browser AI and enterprise device fleets.</p>
-          </article>
-          <article class="tile">
-            <span class="tag">Simple</span>
-            <h3>LiteLLM Link</h3>
-            <p>Short and friendly. Good menu-bar feel, but weaker at communicating governance.</p>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="section-inner">
-        <div class="section-title">
-          <h2>Source notes</h2>
-          <p>These are the current references behind the product scope and implementation constraints.</p>
-        </div>
-        <ul class="source-list">
-          <li><a href="https://www.getmaxim.ai/bifrost/edge">Bifrost Edge product page</a>: market positioning around desktop apps, browser AI, coding tools, and gateway governance.</li>
-          <li><a href="https://docs.getbifrost.ai/edge/overview">Bifrost Edge docs</a>: machine-level routing and governance claims.</li>
-          <li><a href="https://docs.mitmproxy.org/stable/concepts/modes/">mitmproxy local capture</a>: local app capture pattern for transparent interception.</li>
-          <li><a href="https://docs.mitmproxy.org/stable/concepts/certificates/">mitmproxy certificates</a>: HTTPS decryption requires trusted CA installation.</li>
-          <li><a href="https://developer.chrome.com/docs/extensions/reference/api/webRequest">Chrome webRequest</a> and <a href="https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest">declarativeNetRequest</a>: browser extension capture and modification limits.</li>
-          <li><a href="https://www.notion.com/help/network-control">Notion Network Control</a>: Notion documents enterprise SSL proxy/CASB interception patterns for workspace controls.</li>
-          <li><a href="https://developer.apple.com/documentation/networkextension/netransparentproxyprovider">Apple NETransparentProxyProvider</a>: production fallback for transparent macOS capture.</li>
-          <li><a href="https://support.apple.com/guide/deployment/global-http-proxy-payload-settings-dep7ba46fcd/web">Apple Global HTTP Proxy payload</a>: MDM-managed proxy/PAC deployment path.</li>
-        </ul>
-      </div>
-    </section>
+        <div class="code">curl -I -x http://127.0.0.1:4142 https://www.notion.so</div>
+        <p>
+          Default mode does not decrypt TLS or read prompts. It captures proxy metadata
+          and can send redacted shadow events through LiteLLM Gateway.
+        </p>
+      </aside>
+    </div>
   </main>
-
-  <footer>
-    Prepared as a V0 scope artifact for a new LiteLLM repository. The live Notion evidence is metadata-only until Relay is installed with a managed proxy or test CA.
-  </footer>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ chmod 700 "$RELAY_HOME/bin/run-relay"
 cat > "$RELAY_HOME/relay.pac" <<PAC
 function FindProxyForURL(url, host) {
   var relayProxy = "PROXY 127.0.0.1:$RELAY_PORT";
-  var notionDomains = ["notion.so", "notion.com", "api.notion.com", "www.notion.so", "app.notion.com"];
+  var notionDomains = ["notion.so", "notion.com", "api.notion.com", "www.notion.so", "app.notion.com", "api.openai.com", "openai.com", "chatgpt.com", "api.anthropic.com", "anthropic.com", "claude.ai"];
   host = host.toLowerCase();
   for (var i = 0; i < notionDomains.length; i++) {
     var domain = notionDomains[i];
@@ -135,12 +135,16 @@ cat <<DONE
 LiteLLM Relay installed.
 
 Relay proxy: 127.0.0.1:$RELAY_PORT
+Dashboard:   http://127.0.0.1:$RELAY_PORT/
 PAC URL:     http://127.0.0.1:$RELAY_PORT/proxy.pac
 Logs:        $RELAY_HOME/relay.log.jsonl
 
 To route Notion through Relay for a manual pilot:
   networksetup -setautoproxyurl "Wi-Fi" http://127.0.0.1:$RELAY_PORT/proxy.pac
   networksetup -setautoproxystate "Wi-Fi" on
+
+To verify interception without changing system settings:
+  curl -I -x http://127.0.0.1:$RELAY_PORT https://www.notion.so
 
 To enable shadow calls through LiteLLM Gateway, set LITELLM_GATEWAY_API_KEY and
 LITELLM_RELAY_SHADOW_ENABLED=1 before running install.sh, then restart Relay.

--- a/src/litellm_relay/config.py
+++ b/src/litellm_relay/config.py
@@ -13,6 +13,16 @@ DEFAULT_NOTION_DOMAINS = (
     "app.notion.com",
 )
 
+DEFAULT_AI_DOMAINS = (
+    *DEFAULT_NOTION_DOMAINS,
+    "api.openai.com",
+    "openai.com",
+    "chatgpt.com",
+    "api.anthropic.com",
+    "anthropic.com",
+    "claude.ai",
+)
+
 
 @dataclass(frozen=True)
 class RelayConfig:
@@ -20,6 +30,7 @@ class RelayConfig:
     port: int = 4142
     log_path: Path = Path.home() / ".litellm-relay" / "relay.log.jsonl"
     notion_domains: tuple[str, ...] = DEFAULT_NOTION_DOMAINS
+    ai_domains: tuple[str, ...] = DEFAULT_AI_DOMAINS
     shadow_enabled: bool = False
     gateway_url: str = "http://127.0.0.1:4000"
     gateway_api_key: str | None = None
@@ -30,11 +41,11 @@ class RelayConfig:
 
     @classmethod
     def from_env(cls) -> "RelayConfig":
-        domains = os.getenv("LITELLM_RELAY_NOTION_DOMAINS")
-        parsed_domains = (
-            tuple(d.strip().lower() for d in domains.split(",") if d.strip())
-            if domains
-            else DEFAULT_NOTION_DOMAINS
+        notion_domains = parse_domains(
+            os.getenv("LITELLM_RELAY_NOTION_DOMAINS"), DEFAULT_NOTION_DOMAINS
+        )
+        ai_domains = parse_domains(
+            os.getenv("LITELLM_RELAY_AI_DOMAINS"), DEFAULT_AI_DOMAINS
         )
         return cls(
             host=os.getenv("LITELLM_RELAY_HOST", "127.0.0.1"),
@@ -45,7 +56,8 @@ class RelayConfig:
                     str(Path.home() / ".litellm-relay" / "relay.log.jsonl"),
                 )
             ),
-            notion_domains=parsed_domains,
+            notion_domains=notion_domains,
+            ai_domains=ai_domains,
             shadow_enabled=os.getenv("LITELLM_RELAY_SHADOW_ENABLED", "").lower()
             in {"1", "true", "yes", "on"},
             gateway_url=os.getenv("LITELLM_GATEWAY_URL", "http://127.0.0.1:4000"),
@@ -58,6 +70,12 @@ class RelayConfig:
                 os.getenv("LITELLM_RELAY_REQUEST_TIMEOUT_SECONDS", "10")
             ),
         )
+
+
+def parse_domains(raw: str | None, default: tuple[str, ...]) -> tuple[str, ...]:
+    if not raw:
+        return default
+    return tuple(d.strip().lower() for d in raw.split(",") if d.strip())
 
 
 def normalize_host(host: str) -> str:
@@ -75,3 +93,19 @@ def is_domain_match(host: str, domains: tuple[str, ...]) -> bool:
 def is_notion_host(host: str, config: RelayConfig) -> bool:
     return is_domain_match(host, config.notion_domains)
 
+
+def is_ai_host(host: str, config: RelayConfig) -> bool:
+    return is_domain_match(host, config.ai_domains)
+
+
+def classify_host(host: str, config: RelayConfig) -> str:
+    normalized = normalize_host(host)
+    if is_domain_match(normalized, config.notion_domains):
+        return "notion"
+    if is_domain_match(normalized, ("api.openai.com", "openai.com", "chatgpt.com")):
+        return "openai"
+    if is_domain_match(normalized, ("api.anthropic.com", "anthropic.com", "claude.ai")):
+        return "anthropic"
+    if is_ai_host(normalized, config):
+        return "ai"
+    return "unknown"

--- a/src/litellm_relay/pac.py
+++ b/src/litellm_relay/pac.py
@@ -4,7 +4,7 @@ from .config import RelayConfig
 
 
 def build_pac(config: RelayConfig) -> str:
-    domains = ",\n    ".join(f'"{domain}"' for domain in config.notion_domains)
+    domains = ",\n    ".join(f'"{domain}"' for domain in config.ai_domains)
     return f"""function FindProxyForURL(url, host) {{
   var relayProxy = "PROXY {config.host}:{config.port}";
   var notionDomains = [
@@ -22,4 +22,3 @@ def build_pac(config: RelayConfig) -> str:
   return "DIRECT";
 }}
 """
-

--- a/src/litellm_relay/proxy.py
+++ b/src/litellm_relay/proxy.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from datetime import datetime, timezone
 import json
+import time
+from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
-from .config import RelayConfig, is_notion_host, normalize_host
+from .config import RelayConfig, classify_host, is_ai_host, is_notion_host, normalize_host
 from .pac import build_pac
 from .shadow import ShadowClient
+from .ui import DASHBOARD_HTML
 
 
 class RelayProxy:
@@ -49,14 +53,58 @@ class RelayProxy:
             await self._write_response(writer, 400, b"bad request\n")
             return
 
-        if method.upper() == "GET" and target in {"/proxy.pac", "/pac"}:
-            pac = build_pac(self.config).encode("utf-8")
+        method = method.upper()
+        route = parse_route(target)
+
+        if method in {"GET", "HEAD"} and route.path in {"/", "/index.html"}:
             await self._write_response(
-                writer, 200, pac, content_type="application/x-ns-proxy-autoconfig"
+                writer,
+                200,
+                DASHBOARD_HTML.encode("utf-8"),
+                content_type="text/html; charset=utf-8",
+                include_body=method == "GET",
             )
             return
 
-        if method.upper() == "CONNECT":
+        if method in {"GET", "HEAD"} and route.path in {"/proxy.pac", "/pac"}:
+            pac = build_pac(self.config).encode("utf-8")
+            await self._write_response(
+                writer,
+                200,
+                pac,
+                content_type="application/x-ns-proxy-autoconfig",
+                include_body=method == "GET",
+            )
+            return
+
+        if method == "GET" and route.path == "/api/status":
+            await self._write_json(writer, self._status_payload())
+            return
+
+        if method == "GET" and route.path == "/api/events":
+            limit = parse_limit(route.query)
+            await self._write_json(
+                writer,
+                {
+                    "events": read_events(self.config.log_path, limit=limit),
+                    "limit": limit,
+                },
+            )
+            return
+
+        if method == "POST" and route.path == "/api/events/clear":
+            self.config.log_path.parent.mkdir(parents=True, exist_ok=True)
+            self.config.log_path.write_text("", encoding="utf-8")
+            self._log(
+                {
+                    "event": "relay_log_cleared",
+                    "listen": f"{self.config.host}:{self.config.port}",
+                }
+            )
+            await self._write_json(writer, {"ok": True})
+            return
+
+        if method == "CONNECT":
             await self._handle_connect(target, peer, reader, writer)
             return
 
@@ -74,18 +122,23 @@ class RelayProxy:
         client_writer: asyncio.StreamWriter,
     ) -> None:
         host, port = parse_connect_target(target)
+        started_at = time.monotonic()
+        event_id = str(uuid4())
         event = self._event(
             {
+                "event_id": event_id,
                 "event": "connect",
                 "method": "CONNECT",
                 "host": host,
                 "port": port,
                 "peer": repr(peer),
+                "app": classify_host(host, self.config),
+                "ai_match": is_ai_host(host, self.config),
                 "notion_match": is_notion_host(host, self.config),
             }
         )
 
-        if event["notion_match"]:
+        if event["ai_match"]:
             shadow_result = self.shadow_client.maybe_shadow(event)
             event["shadow"] = {
                 "attempted": shadow_result.attempted,
@@ -114,7 +167,27 @@ class RelayProxy:
 
         client_writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         await client_writer.drain()
-        await tunnel(client_reader, client_writer, upstream_reader, upstream_writer)
+        bytes_out, bytes_in = await tunnel(
+            client_reader, client_writer, upstream_reader, upstream_writer
+        )
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        self._log(
+            self._event(
+                {
+                    "event_id": event_id,
+                    "event": "connect_closed",
+                    "method": "CONNECT",
+                    "host": host,
+                    "port": port,
+                    "app": classify_host(host, self.config),
+                    "ai_match": is_ai_host(host, self.config),
+                    "notion_match": is_notion_host(host, self.config),
+                    "duration_ms": duration_ms,
+                    "bytes_out": bytes_out,
+                    "bytes_in": bytes_in,
+                }
+            )
+        )
 
     async def _write_response(
         self,
@@ -122,6 +195,7 @@ class RelayProxy:
         status: int,
         body: bytes,
         content_type: str = "text/plain",
+        include_body: bool = True,
     ) -> None:
         reason = {
             200: "OK",
@@ -134,14 +208,25 @@ class RelayProxy:
                 f"HTTP/1.1 {status} {reason}\r\n"
                 f"content-length: {len(body)}\r\n"
                 f"content-type: {content_type}\r\n"
+                "cache-control: no-store\r\n"
                 "connection: close\r\n"
                 "\r\n"
             ).encode("ascii")
-            + body
+            + (body if include_body else b"")
         )
         await writer.drain()
         writer.close()
         await writer.wait_closed()
+
+    async def _write_json(
+        self, writer: asyncio.StreamWriter, payload: dict[str, object], status: int = 200
+    ) -> None:
+        await self._write_response(
+            writer,
+            status,
+            json.dumps(payload, sort_keys=True).encode("utf-8"),
+            content_type="application/json; charset=utf-8",
+        )
 
     def _event(self, values: dict[str, object]) -> dict[str, object]:
         return {
@@ -155,28 +240,83 @@ class RelayProxy:
         with self.config.log_path.open("a", encoding="utf-8") as log_file:
             log_file.write(json.dumps(redact_event(event), sort_keys=True) + "\n")
 
+    def _status_payload(self) -> dict[str, object]:
+        return {
+            "listen": f"{self.config.host}:{self.config.port}",
+            "log_path": str(self.config.log_path),
+            "ai_domains": list(self.config.ai_domains),
+            "notion_domains": list(self.config.notion_domains),
+            "shadow_enabled": self.config.shadow_enabled,
+            "gateway_url": self.config.gateway_url,
+            "events_loaded": len(read_events(self.config.log_path, limit=1000)),
+        }
+
 
 async def tunnel(
     client_reader: asyncio.StreamReader,
     client_writer: asyncio.StreamWriter,
     upstream_reader: asyncio.StreamReader,
     upstream_writer: asyncio.StreamWriter,
-) -> None:
-    async def pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+) -> tuple[int, int]:
+    async def pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> int:
+        byte_count = 0
         try:
             while chunk := await reader.read(65536):
+                byte_count += len(chunk)
                 writer.write(chunk)
                 await writer.drain()
         except (ConnectionError, asyncio.CancelledError):
             pass
         finally:
             writer.close()
+        return byte_count
 
-    await asyncio.gather(
+    results = await asyncio.gather(
         pipe(client_reader, upstream_writer),
         pipe(upstream_reader, client_writer),
         return_exceptions=True,
     )
+    bytes_out = results[0] if isinstance(results[0], int) else 0
+    bytes_in = results[1] if isinstance(results[1], int) else 0
+    return bytes_out, bytes_in
+
+
+class Route:
+    def __init__(self, path: str, query: str):
+        self.path = path
+        self.query = query
+
+
+def parse_route(target: str) -> Route:
+    parsed = urlsplit(target)
+    path = parsed.path or "/"
+    return Route(path=path, query=parsed.query)
+
+
+def parse_limit(query: str) -> int:
+    raw = parse_qs(query).get("limit", ["250"])[0]
+    try:
+        return max(1, min(int(raw), 1000))
+    except ValueError:
+        return 250
+
+
+def read_events(log_path, limit: int = 250) -> list[dict[str, object]]:
+    if not log_path.exists():
+        return []
+    events: deque[dict[str, object]] = deque(maxlen=limit)
+    with log_path.open("r", encoding="utf-8") as log_file:
+        for line in log_file:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                events.append(event)
+    return list(events)
 
 
 def parse_connect_target(target: str) -> tuple[str, int]:

--- a/src/litellm_relay/shadow.py
+++ b/src/litellm_relay/shadow.py
@@ -99,14 +99,14 @@ def build_shadow_payload(
                 "role": "user",
                 "content": (
                     "Return exactly OK. "
-                    f"source=notion-mac method={event.get('method', 'CONNECT')} "
+                    f"source={event.get('app', 'ai')} method={event.get('method', 'CONNECT')} "
                     f"event_id={event_id} host_hash={host_hash[:16]}"
                 ),
             },
         ],
         "metadata": {
             "source": "litellm-relay",
-            "shadow_source": "notion-mac",
+            "shadow_source": str(event.get("app") or "ai"),
             "event_id": event_id,
             "host_hash": host_hash,
             "method": str(event.get("method", "CONNECT")),

--- a/src/litellm_relay/ui.py
+++ b/src/litellm_relay/ui.py
@@ -1,0 +1,691 @@
+from __future__ import annotations
+
+
+DASHBOARD_HTML = r"""<!doctype html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LiteLLM Relay</title>
+  <style>
+    :root {
+      --background: 240 10% 3.9%;
+      --foreground: 0 0% 98%;
+      --card: 240 10% 3.9%;
+      --card-foreground: 0 0% 98%;
+      --popover: 240 10% 3.9%;
+      --popover-foreground: 0 0% 98%;
+      --primary: 162 74% 45%;
+      --primary-foreground: 164 95% 8%;
+      --secondary: 240 3.7% 15.9%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 3.7% 15.9%;
+      --muted-foreground: 240 5% 64.9%;
+      --accent: 240 3.7% 15.9%;
+      --accent-foreground: 0 0% 98%;
+      --destructive: 0 62.8% 50.6%;
+      --destructive-foreground: 0 0% 98%;
+      --border: 240 3.7% 15.9%;
+      --input: 240 3.7% 15.9%;
+      --ring: 162 74% 45%;
+      --radius: 0.625rem;
+      --font-sans: "Geist", "Geist Fallback", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-mono: "Geist Mono", "Geist Mono Fallback", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: hsl(var(--foreground));
+      background: hsl(var(--background));
+      font-family: var(--font-sans);
+      letter-spacing: 0;
+    }
+
+    button, input, select {
+      font: inherit;
+    }
+
+    .app {
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 280px minmax(0, 1fr);
+    }
+
+    .sidebar {
+      border-right: 1px solid hsl(var(--border));
+      background: hsl(240 10% 4.5%);
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-height: 40px;
+    }
+
+    .logo {
+      width: 32px;
+      height: 32px;
+      border: 1px solid hsl(var(--primary));
+      border-radius: 8px;
+      display: grid;
+      place-items: center;
+      color: hsl(var(--primary));
+      font-family: var(--font-mono);
+      box-shadow: 0 0 0 1px hsl(var(--primary) / 0.16), 0 0 28px hsl(var(--primary) / 0.16);
+    }
+
+    .brand-title {
+      font-weight: 650;
+      line-height: 1.1;
+    }
+
+    .brand-subtitle {
+      color: hsl(var(--muted-foreground));
+      font-size: 12px;
+      margin-top: 3px;
+    }
+
+    .nav {
+      display: grid;
+      gap: 6px;
+    }
+
+    .nav-item {
+      border: 1px solid transparent;
+      border-radius: calc(var(--radius) - 2px);
+      padding: 10px 12px;
+      color: hsl(var(--muted-foreground));
+      background: transparent;
+      text-align: left;
+      font-size: 14px;
+    }
+
+    .nav-item.active {
+      color: hsl(var(--foreground));
+      background: hsl(var(--accent));
+      border-color: hsl(var(--border));
+    }
+
+    .sidebar-card {
+      margin-top: auto;
+      border: 1px solid hsl(var(--border));
+      border-radius: var(--radius);
+      background: hsl(var(--card));
+      padding: 14px;
+      color: hsl(var(--muted-foreground));
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .content {
+      min-width: 0;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 26px;
+      line-height: 1.2;
+      font-weight: 720;
+    }
+
+    .lead {
+      margin: 6px 0 0;
+      color: hsl(var(--muted-foreground));
+      font-size: 14px;
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .button {
+      min-height: 36px;
+      border-radius: calc(var(--radius) - 2px);
+      border: 1px solid hsl(var(--border));
+      padding: 0 12px;
+      background: hsl(var(--secondary));
+      color: hsl(var(--secondary-foreground));
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+    }
+
+    .button.primary {
+      background: hsl(var(--primary));
+      color: hsl(var(--primary-foreground));
+      border-color: hsl(var(--primary));
+      font-weight: 650;
+    }
+
+    .button.ghost {
+      background: transparent;
+    }
+
+    .button:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .card {
+      border: 1px solid hsl(var(--border));
+      border-radius: var(--radius);
+      background: hsl(var(--card));
+      color: hsl(var(--card-foreground));
+      box-shadow: 0 1px 2px hsl(0 0% 0% / 0.18);
+    }
+
+    .metric {
+      padding: 16px;
+    }
+
+    .metric-label {
+      color: hsl(var(--muted-foreground));
+      font-size: 12px;
+      text-transform: uppercase;
+      font-weight: 650;
+      letter-spacing: 0.06em;
+    }
+
+    .metric-value {
+      margin-top: 8px;
+      font: 700 28px/1 var(--font-mono);
+    }
+
+    .metric-foot {
+      margin-top: 8px;
+      color: hsl(var(--muted-foreground));
+      font-size: 12px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px;
+    }
+
+    .filters {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .input, .select {
+      min-height: 36px;
+      border-radius: calc(var(--radius) - 2px);
+      border: 1px solid hsl(var(--input));
+      background: hsl(var(--background));
+      color: hsl(var(--foreground));
+      padding: 0 11px;
+      outline: none;
+    }
+
+    .input:focus, .select:focus {
+      border-color: hsl(var(--ring));
+      box-shadow: 0 0 0 3px hsl(var(--ring) / 0.18);
+    }
+
+    .input {
+      width: min(340px, 52vw);
+    }
+
+    .table-wrap {
+      overflow: auto;
+      border-top: 1px solid hsl(var(--border));
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 920px;
+    }
+
+    th, td {
+      border-bottom: 1px solid hsl(var(--border));
+      padding: 12px 14px;
+      text-align: left;
+      vertical-align: middle;
+      font-size: 13px;
+    }
+
+    th {
+      color: hsl(var(--muted-foreground));
+      font-weight: 650;
+      background: hsl(240 4% 8%);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    td.mono, .mono {
+      font-family: var(--font-mono);
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border: 1px solid hsl(var(--border));
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-weight: 650;
+      white-space: nowrap;
+      background: hsl(var(--secondary));
+      color: hsl(var(--secondary-foreground));
+    }
+
+    .badge.green {
+      border-color: hsl(var(--primary) / 0.35);
+      background: hsl(var(--primary) / 0.12);
+      color: hsl(162 80% 70%);
+    }
+
+    .badge.red {
+      border-color: hsl(var(--destructive) / 0.42);
+      background: hsl(var(--destructive) / 0.14);
+      color: hsl(0 84% 72%);
+    }
+
+    .badge.yellow {
+      border-color: hsl(38 92% 50% / 0.35);
+      background: hsl(38 92% 50% / 0.12);
+      color: hsl(42 92% 72%);
+    }
+
+    .dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 999px;
+      background: currentColor;
+    }
+
+    .empty {
+      min-height: 220px;
+      display: grid;
+      place-items: center;
+      color: hsl(var(--muted-foreground));
+      text-align: center;
+      padding: 28px;
+    }
+
+    .empty strong {
+      color: hsl(var(--foreground));
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    .details {
+      padding: 16px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .code {
+      background: hsl(240 10% 6%);
+      border: 1px solid hsl(var(--border));
+      border-radius: calc(var(--radius) - 2px);
+      padding: 12px;
+      overflow: auto;
+      color: hsl(var(--muted-foreground));
+      font: 12px/1.6 var(--font-mono);
+    }
+
+    .toast {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      max-width: 360px;
+      border: 1px solid hsl(var(--border));
+      border-radius: var(--radius);
+      background: hsl(var(--popover));
+      color: hsl(var(--popover-foreground));
+      padding: 12px 14px;
+      box-shadow: 0 16px 40px hsl(0 0% 0% / 0.35);
+      display: none;
+      font-size: 13px;
+    }
+
+    .toast.show {
+      display: block;
+    }
+
+    @media (max-width: 980px) {
+      .app { grid-template-columns: 1fr; }
+      .sidebar {
+        border-right: 0;
+        border-bottom: 1px solid hsl(var(--border));
+      }
+      .sidebar-card { margin-top: 0; }
+      .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .header { flex-direction: column; }
+      .actions { justify-content: flex-start; }
+    }
+
+    @media (max-width: 620px) {
+      .content { padding: 16px; }
+      .grid { grid-template-columns: 1fr; }
+      .toolbar { align-items: stretch; flex-direction: column; }
+      .input { width: 100%; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <div class="brand">
+        <div class="logo">L</div>
+        <div>
+          <div class="brand-title">LiteLLM Relay</div>
+          <div class="brand-subtitle">Local traffic proxy</div>
+        </div>
+      </div>
+      <div class="nav">
+        <button class="nav-item active">Intercepted traffic</button>
+        <button class="nav-item" onclick="scrollToCard('config-card')">Proxy setup</button>
+        <button class="nav-item" onclick="scrollToCard('raw-card')">Raw event</button>
+      </div>
+      <div class="sidebar-card">
+        <strong style="color:hsl(var(--foreground));">Default mode</strong><br>
+        HTTPS payloads stay encrypted. Relay records CONNECT metadata and optional
+        redacted shadow calls through LiteLLM Gateway.
+      </div>
+    </aside>
+
+    <main class="content">
+      <header class="header">
+        <div>
+          <h1>Intercepted AI traffic</h1>
+          <p class="lead">Live local view of AI traffic routed through this Relay process.</p>
+        </div>
+        <div class="actions">
+          <span id="live-badge" class="badge green"><span class="dot"></span> Live</span>
+          <button id="pause-button" class="button ghost" type="button">Pause</button>
+          <button id="copy-pac" class="button" type="button">Copy PAC URL</button>
+          <button id="refresh-button" class="button primary" type="button">Refresh</button>
+        </div>
+      </header>
+
+      <section class="grid" aria-label="Traffic metrics">
+        <div class="card metric">
+          <div class="metric-label">Events</div>
+          <div id="metric-events" class="metric-value">0</div>
+          <div class="metric-foot">Total log rows loaded</div>
+        </div>
+        <div class="card metric">
+          <div class="metric-label">AI matches</div>
+          <div id="metric-ai" class="metric-value">0</div>
+          <div class="metric-foot">OpenAI, Anthropic, Notion, and configured hosts</div>
+        </div>
+        <div class="card metric">
+          <div class="metric-label">Shadowed</div>
+          <div id="metric-shadow" class="metric-value">0</div>
+          <div class="metric-foot">Gateway shadow attempts</div>
+        </div>
+        <div class="card metric">
+          <div class="metric-label">Bytes</div>
+          <div id="metric-bytes" class="metric-value">0</div>
+          <div class="metric-foot">Closed tunnel bytes</div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="toolbar">
+          <div class="filters">
+            <input id="search" class="input" placeholder="Filter host, event id, method..." />
+            <select id="kind-filter" class="select">
+              <option value="all">All events</option>
+              <option value="ai">AI only</option>
+              <option value="shadow">Shadow attempts</option>
+              <option value="closed">Closed tunnels</option>
+            </select>
+          </div>
+          <div class="mono" style="color:hsl(var(--muted-foreground)); font-size:12px;">
+            Last update <span id="last-update">never</span>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Event</th>
+                <th>Host</th>
+                <th>App</th>
+                <th>Port</th>
+                <th>Shadow</th>
+                <th>Duration</th>
+                <th>Bytes</th>
+                <th>Event ID</th>
+              </tr>
+            </thead>
+            <tbody id="events-body"></tbody>
+          </table>
+          <div id="empty" class="empty">
+            <div>
+              <strong>No intercepted traffic yet</strong>
+              Route an app through the PAC URL or run:
+              <div class="code" style="margin-top:12px; text-align:left;">curl -I -x http://127.0.0.1:4142 https://www.notion.so</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="config-card" class="card details">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+          <div>
+            <div style="font-weight:650;">Proxy setup</div>
+            <div style="color:hsl(var(--muted-foreground));font-size:13px;">Use this PAC URL to route supported AI apps through Relay.</div>
+          </div>
+          <span id="status-badge" class="badge">Loading</span>
+        </div>
+        <div id="config-code" class="code">Loading...</div>
+      </section>
+
+      <section id="raw-card" class="card details">
+        <div>
+          <div style="font-weight:650;">Selected raw event</div>
+          <div style="color:hsl(var(--muted-foreground));font-size:13px;">Click a table row to inspect the redacted JSON event.</div>
+        </div>
+        <pre id="raw-event" class="code">No event selected.</pre>
+      </section>
+    </main>
+  </div>
+
+  <div id="toast" class="toast"></div>
+
+  <script>
+    const state = {
+      events: [],
+      paused: false,
+      selected: null,
+      status: null,
+    };
+
+    const $ = (id) => document.getElementById(id);
+
+    function fmtTime(value) {
+      if (!value) return "";
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return value;
+      return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    }
+
+    function fmtBytes(value) {
+      const n = Number(value || 0);
+      if (n < 1024) return String(n);
+      if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+      return `${(n / 1024 / 1024).toFixed(1)} MB`;
+    }
+
+    function toast(message) {
+      const node = $("toast");
+      node.textContent = message;
+      node.classList.add("show");
+      setTimeout(() => node.classList.remove("show"), 2200);
+    }
+
+    function badgeForEvent(event) {
+      if (event.event === "connect_failed") return '<span class="badge red">failed</span>';
+      if (event.event === "connect_closed") return '<span class="badge">closed</span>';
+      if (event.ai_match) return '<span class="badge green">ai</span>';
+      if (event.event === "relay_started") return '<span class="badge yellow">relay</span>';
+      return '<span class="badge">event</span>';
+    }
+
+    function shadowBadge(event) {
+      if (!event.shadow) return '<span class="badge">none</span>';
+      if (event.shadow.ok) return '<span class="badge green">ok</span>';
+      if (event.shadow.attempted) return '<span class="badge red">failed</span>';
+      return '<span class="badge yellow">skipped</span>';
+    }
+
+    function filteredEvents() {
+      const query = $("search").value.trim().toLowerCase();
+      const kind = $("kind-filter").value;
+      return state.events.filter((event) => {
+        if (kind === "ai" && !event.ai_match) return false;
+        if (kind === "shadow" && !event.shadow?.attempted) return false;
+        if (kind === "closed" && event.event !== "connect_closed") return false;
+        if (!query) return true;
+        return JSON.stringify(event).toLowerCase().includes(query);
+      });
+    }
+
+    function renderMetrics(events) {
+      const ai = events.filter((event) => event.ai_match).length;
+      const shadow = events.filter((event) => event.shadow?.attempted).length;
+      const bytes = events.reduce((total, event) => total + Number(event.bytes_in || 0) + Number(event.bytes_out || 0), 0);
+      $("metric-events").textContent = String(events.length);
+      $("metric-ai").textContent = String(ai);
+      $("metric-shadow").textContent = String(shadow);
+      $("metric-bytes").textContent = fmtBytes(bytes);
+    }
+
+    function renderTable() {
+      const events = filteredEvents();
+      renderMetrics(state.events);
+      const body = $("events-body");
+      body.innerHTML = "";
+      $("empty").style.display = events.length ? "none" : "grid";
+      for (const event of events.slice().reverse()) {
+        const row = document.createElement("tr");
+        row.tabIndex = 0;
+        row.style.cursor = "pointer";
+        row.innerHTML = `
+          <td class="mono">${fmtTime(event.timestamp)}</td>
+          <td>${badgeForEvent(event)}</td>
+          <td class="mono">${event.host || event.listen || "-"}</td>
+          <td>${event.app ? `<span class="badge">${event.app}</span>` : "-"}</td>
+          <td class="mono">${event.port || "-"}</td>
+          <td>${shadowBadge(event)}</td>
+          <td class="mono">${event.duration_ms ? `${event.duration_ms} ms` : "-"}</td>
+          <td class="mono">${event.bytes_in || event.bytes_out ? `${fmtBytes(event.bytes_in)} / ${fmtBytes(event.bytes_out)}` : "-"}</td>
+          <td class="mono">${event.event_id || "-"}</td>
+        `;
+        row.addEventListener("click", () => selectEvent(event));
+        row.addEventListener("keydown", (evt) => {
+          if (evt.key === "Enter") selectEvent(event);
+        });
+        body.appendChild(row);
+      }
+    }
+
+    function selectEvent(event) {
+      state.selected = event;
+      $("raw-event").textContent = JSON.stringify(event, null, 2);
+      scrollToCard("raw-card");
+    }
+
+    function renderStatus() {
+      const status = state.status;
+      if (!status) return;
+      $("status-badge").className = status.shadow_enabled ? "badge green" : "badge yellow";
+      $("status-badge").textContent = status.shadow_enabled ? "Shadow enabled" : "Shadow off";
+      $("config-code").textContent = [
+        `Dashboard: ${location.origin}/`,
+        `PAC URL:   ${location.origin}/proxy.pac`,
+        `Proxy:     ${status.listen}`,
+        `Log file:  ${status.log_path}`,
+        `AI domains: ${status.ai_domains.join(", ")}`,
+      ].join("\n");
+    }
+
+    async function loadStatus() {
+      const response = await fetch("/api/status", { cache: "no-store" });
+      state.status = await response.json();
+      renderStatus();
+    }
+
+    async function loadEvents() {
+      if (state.paused) return;
+      const response = await fetch("/api/events?limit=500", { cache: "no-store" });
+      const payload = await response.json();
+      state.events = payload.events || [];
+      $("last-update").textContent = new Date().toLocaleTimeString();
+      renderTable();
+    }
+
+    function scrollToCard(id) {
+      document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+
+    $("refresh-button").addEventListener("click", () => {
+      loadStatus();
+      loadEvents();
+    });
+    $("pause-button").addEventListener("click", () => {
+      state.paused = !state.paused;
+      $("pause-button").textContent = state.paused ? "Resume" : "Pause";
+      $("live-badge").className = state.paused ? "badge yellow" : "badge green";
+      $("live-badge").innerHTML = `<span class="dot"></span> ${state.paused ? "Paused" : "Live"}`;
+    });
+    $("copy-pac").addEventListener("click", async () => {
+      await navigator.clipboard.writeText(`${location.origin}/proxy.pac`);
+      toast("PAC URL copied");
+    });
+    $("search").addEventListener("input", renderTable);
+    $("kind-filter").addEventListener("change", renderTable);
+
+    loadStatus().catch((error) => toast(`Status failed: ${error.message}`));
+    loadEvents().catch((error) => toast(`Events failed: ${error.message}`));
+    setInterval(loadEvents, 1500);
+  </script>
+</body>
+</html>
+"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import unittest
 
-from litellm_relay.config import RelayConfig, is_notion_host, normalize_host
+from litellm_relay.config import RelayConfig, classify_host, is_ai_host, is_notion_host, normalize_host
 
 
 class ConfigTests(unittest.TestCase):
@@ -13,6 +13,18 @@ class ConfigTests(unittest.TestCase):
         self.assertTrue(is_notion_host("www.notion.so:443", config))
         self.assertTrue(is_notion_host("app.notion.com", config))
         self.assertFalse(is_notion_host("example.com", config))
+
+    def test_is_ai_host_matches_openai_and_notion(self):
+        config = RelayConfig()
+        self.assertTrue(is_ai_host("api.openai.com:443", config))
+        self.assertTrue(is_ai_host("www.notion.so", config))
+        self.assertFalse(is_ai_host("example.com", config))
+
+    def test_classify_host_returns_known_apps(self):
+        config = RelayConfig()
+        self.assertEqual(classify_host("api.openai.com", config), "openai")
+        self.assertEqual(classify_host("api.anthropic.com", config), "anthropic")
+        self.assertEqual(classify_host("www.notion.so", config), "notion")
 
 
 if __name__ == "__main__":

--- a/tests/test_pac.py
+++ b/tests/test_pac.py
@@ -5,10 +5,11 @@ from litellm_relay.pac import build_pac
 
 
 class PacTests(unittest.TestCase):
-    def test_build_pac_routes_only_notion_domains(self):
+    def test_build_pac_routes_ai_domains(self):
         pac = build_pac(RelayConfig(port=4142))
         self.assertIn("PROXY 127.0.0.1:4142", pac)
         self.assertIn('"notion.so"', pac)
+        self.assertIn('"api.openai.com"', pac)
         self.assertIn('return "DIRECT"', pac)
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,6 +1,9 @@
 import unittest
 
-from litellm_relay.proxy import parse_connect_target, redact_event
+from pathlib import Path
+import tempfile
+
+from litellm_relay.proxy import parse_connect_target, parse_limit, parse_route, read_events, redact_event
 
 
 class ProxyTests(unittest.TestCase):
@@ -10,6 +13,25 @@ class ProxyTests(unittest.TestCase):
 
     def test_parse_connect_target_reads_port(self):
         self.assertEqual(parse_connect_target("www.notion.so:443"), ("www.notion.so", 443))
+
+    def test_parse_route_reads_path_and_query(self):
+        route = parse_route("/api/events?limit=50")
+        self.assertEqual(route.path, "/api/events")
+        self.assertEqual(route.query, "limit=50")
+
+    def test_parse_limit_clamps_invalid_values(self):
+        self.assertEqual(parse_limit("limit=2"), 2)
+        self.assertEqual(parse_limit("limit=999999"), 1000)
+        self.assertEqual(parse_limit("limit=nope"), 250)
+
+    def test_read_events_skips_bad_json_and_limits_rows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "relay.log.jsonl"
+            log_path.write_text(
+                '{"event":"one"}\nnot-json\n{"event":"two"}\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(read_events(log_path, limit=1), [{"event": "two"}])
 
 
     def test_redact_event_drops_sensitive_fields(self):


### PR DESCRIPTION
## Summary
- replace the old static plan page with an install/dashboard landing page
- serve a shadcn-style local dashboard from Relay at /
- add /api/status and /api/events so intercepted traffic appears in the UI
- log CONNECT close events with duration and byte counts
- broaden matching from Notion-only to AI domains, including OpenAI/Codex-style traffic
- shadow any matched AI host with redacted Gateway metadata

## Local proof
- started Relay locally on port 4158 with shadowing enabled
- sent an OpenAI/Codex-style request through the proxy: curl -I -x http://127.0.0.1:4158 https://api.openai.com/v1/models
- UI/API showed api.openai.com as app=openai, ai_match=true, shadow ok, plus duration/bytes on close
- dashboard loaded in Chrome with no horizontal overflow

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- PYTHONPATH=src python3 -m compileall -q src tests
- bash -n install.sh && bash -n uninstall.sh
- git diff --check