### PR TITLE
[Fix] Harden relay privacy defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -124,22 +124,12 @@ impl Default for ShadowSection {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CaptureSection {
     pub payloads: bool,
     pub payload_preview_bytes: usize,
     pub payload_body_bytes: usize,
-}
-
-impl Default for CaptureSection {
-    fn default() -> Self {
-        Self {
-            payloads: true,
-            payload_preview_bytes: 8192,
-            payload_body_bytes: 262_144,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -375,6 +365,33 @@ capture:
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.shadow_model, "gpt-4o-mini");
         assert!(!config.ai_domains.is_empty());
+    }
+
+    #[test]
+    fn should_default_to_metadata_only_capture() {
+        let config = RelaySettings::default().to_config();
+
+        assert!(!config.mitm_enabled);
+        assert_eq!(config.payload_preview_bytes, 0);
+        assert_eq!(config.payload_body_bytes, 0);
+    }
+
+    #[test]
+    fn should_preserve_explicit_capture_limits() {
+        let settings: RelaySettings = serde_yaml::from_str(
+            r#"
+capture:
+  payloads: true
+  payload_preview_bytes: 8192
+  payload_body_bytes: 262144
+"#,
+        )
+        .expect("settings yaml should parse");
+        let config = settings.to_config();
+
+        assert!(config.mitm_enabled);
+        assert_eq!(config.payload_preview_bytes, 8192);
+        assert_eq!(config.payload_body_bytes, 262_144);
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,6 +9,8 @@ use anyhow::Result;
 use chrono::Utc;
 use serde_json::Value;
 
+use crate::http::{is_sensitive_name, scrub_request_target};
+
 pub fn append_event(log_path: &Path, event: Value) -> Result<()> {
     if let Some(parent) = log_path.parent() {
         fs::create_dir_all(parent)?;
@@ -50,21 +52,49 @@ pub fn read_events(log_path: &Path, limit: usize) -> Vec<Value> {
 }
 
 pub fn redact_event(mut event: Value) -> Value {
+    redact_value(&mut event);
     if let Value::Object(map) = &mut event {
         map.entry("captured_at")
             .or_insert_with(|| Value::String(Utc::now().to_rfc3339()));
-        for key in [
-            "authorization",
-            "cookie",
-            "token_v2",
-            "prompt",
-            "body",
-            "url",
-        ] {
-            map.remove(key);
-        }
     }
     event
+}
+
+fn redact_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                if should_remove_field(&key) {
+                    map.remove(&key);
+                    continue;
+                }
+                if is_sensitive_name(&key) {
+                    map.insert(key, Value::String("<redacted>".into()));
+                    continue;
+                }
+                if let Some(child) = map.get_mut(&key) {
+                    if matches!(key.as_str(), "path" | "url" | "target") {
+                        if let Value::String(raw) = child {
+                            *raw = scrub_request_target(raw);
+                            continue;
+                        }
+                    }
+                    redact_value(child);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                redact_value(child);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn should_remove_field(key: &str) -> bool {
+    matches!(key.to_ascii_lowercase().as_str(), "body" | "prompt")
 }
 
 #[cfg(test)]
@@ -82,9 +112,32 @@ mod tests {
             "cookie": "token_v2=secret",
             "body": "prompt",
         }));
-        assert!(redacted.get("authorization").is_none());
-        assert!(redacted.get("cookie").is_none());
+        assert_eq!(redacted["authorization"], "<redacted>");
+        assert_eq!(redacted["cookie"], "<redacted>");
         assert!(redacted.get("body").is_none());
         assert_eq!(redacted["host"], "www.notion.so");
+    }
+
+    #[test]
+    fn redact_event_scrubs_nested_headers_and_query_secrets() {
+        let redacted = redact_event(json!({
+            "event": "http_request",
+            "path": "/v1/responses?api_key=sk-secret&model=gpt-4o",
+            "headers": {
+                "x-api-key": "secret",
+                "content-type": "application/json"
+            },
+            "metadata": {
+                "session_id": "abc123"
+            }
+        }));
+
+        assert_eq!(
+            redacted["path"],
+            "/v1/responses?api_key=%3Credacted%3E&model=gpt-4o"
+        );
+        assert_eq!(redacted["headers"]["x-api-key"], "<redacted>");
+        assert_eq!(redacted["headers"]["content-type"], "application/json");
+        assert_eq!(redacted["metadata"]["session_id"], "<redacted>");
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -220,16 +220,9 @@ pub fn should_close(headers: &HashMap<String, String>) -> bool {
 }
 
 pub fn redact_headers(headers: &HashMap<String, String>) -> Value {
-    let sensitive = [
-        "authorization",
-        "cookie",
-        "set-cookie",
-        "x-notion-token",
-        "x-api-key",
-    ];
     let mut redacted = Map::new();
     for (key, value) in headers {
-        let value = if sensitive.contains(&key.as_str()) {
+        let value = if is_sensitive_name(key) {
             "<redacted>"
         } else {
             value
@@ -237,6 +230,76 @@ pub fn redact_headers(headers: &HashMap<String, String>) -> Value {
         redacted.insert(key.clone(), Value::String(value.to_string()));
     }
     Value::Object(redacted)
+}
+
+pub fn scrub_request_target(target: &str) -> String {
+    let parsed = if target.starts_with("http://") || target.starts_with("https://") {
+        url::Url::parse(target)
+    } else {
+        url::Url::parse(&format!("http://relay.local{target}"))
+    };
+    let Ok(mut url) = parsed else {
+        return target.to_string();
+    };
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(key, value)| {
+            let value = if is_sensitive_name(key.as_ref()) {
+                "<redacted>".to_string()
+            } else {
+                value.into_owned()
+            };
+            (key.into_owned(), value)
+        })
+        .collect();
+    url.set_query(None);
+    if !pairs.is_empty() {
+        let mut query = url.query_pairs_mut();
+        for (key, value) in pairs {
+            query.append_pair(&key, &value);
+        }
+    }
+
+    let mut scrubbed = url.path().to_string();
+    if let Some(query) = url.query() {
+        scrubbed.push('?');
+        scrubbed.push_str(query);
+    }
+    scrubbed
+}
+
+pub fn is_sensitive_name(name: &str) -> bool {
+    const SENSITIVE_EXACT: [&str; 10] = [
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "set-cookie",
+        "password",
+        "passwd",
+        "secret",
+        "signature",
+        "sig",
+        "code",
+    ];
+    const SENSITIVE_PARTS: [&str; 14] = [
+        "api-key",
+        "apikey",
+        "auth",
+        "bearer",
+        "client-secret",
+        "credential",
+        "csrf",
+        "id-token",
+        "jwt",
+        "refresh-token",
+        "secret",
+        "session",
+        "token",
+        "xsrf",
+    ];
+    let normalized = name.trim().to_ascii_lowercase().replace('_', "-");
+    SENSITIVE_EXACT.contains(&normalized.as_str())
+        || SENSITIVE_PARTS.iter().any(|part| normalized.contains(part))
 }
 
 pub fn build_http_payload(
@@ -257,7 +320,12 @@ pub fn build_http_payload(
                 "body_preview".into(),
                 json!(preview_bytes(&decoded, preview_limit)),
             );
-            payload.insert("body".into(), json!(preview_bytes(&decoded, body_limit)));
+            let body_value = if body_limit == 0 {
+                Value::Null
+            } else {
+                json!(preview_bytes(&decoded, body_limit))
+            };
+            payload.insert("body".into(), body_value);
             payload.insert("decoded_body_bytes".into(), json!(decoded.len()));
             payload.insert("body_truncated".into(), json!(decoded.len() > body_limit));
             payload.insert(
@@ -412,5 +480,53 @@ mod tests {
         assert_eq!(payload["decoded_body_bytes"], 25);
         assert_eq!(payload["body_truncated"], false);
         assert_eq!(payload["preview_truncated"], true);
+    }
+
+    #[test]
+    fn build_http_payload_omits_body_when_body_limit_is_zero() {
+        let headers = HashMap::from([("content-type".to_string(), "application/json".to_string())]);
+        let payload = build_http_payload(
+            br#"{"prompt":"hello notion"}"#,
+            &headers,
+            10,
+            0,
+            json!({"method": "POST", "path": "/api/v3/runInferenceTranscript"}),
+        );
+
+        assert_eq!(payload["body"], Value::Null);
+        assert_eq!(payload["body_preview"], "{\"prompt\":");
+        assert_eq!(payload["body_truncated"], true);
+        assert_eq!(payload["preview_truncated"], true);
+    }
+
+    #[test]
+    fn redact_headers_redacts_secret_style_names() {
+        let headers = HashMap::from([
+            ("authorization".to_string(), "Bearer token".to_string()),
+            ("x-session-id".to_string(), "session-secret".to_string()),
+            ("x-api-key".to_string(), "sk-secret".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]);
+
+        let redacted = redact_headers(&headers);
+
+        assert_eq!(redacted["authorization"], "<redacted>");
+        assert_eq!(redacted["x-session-id"], "<redacted>");
+        assert_eq!(redacted["x-api-key"], "<redacted>");
+        assert_eq!(redacted["content-type"], "application/json");
+    }
+
+    #[test]
+    fn scrub_request_target_redacts_query_secrets() {
+        let scrubbed = scrub_request_target(
+            "/v1/responses?model=gpt-4o&api_key=sk-secret&session_id=abc&limit=10",
+        );
+
+        assert_eq!(
+            scrubbed,
+            "/v1/responses?model=gpt-4o&api_key=%3Credacted%3E&session_id=%3Credacted%3E&limit=10"
+        );
+        assert!(!scrubbed.contains("sk-secret"));
+        assert!(!scrubbed.contains("abc"));
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -20,7 +20,8 @@ use crate::{
     http::{
         build_http_payload, copy_bidirectional_counted, parse_connect_target, parse_limit,
         parse_request_line, parse_response_status, parse_route, parse_start_line,
-        read_http_message, read_until_headers, redact_headers, should_close, write_response,
+        read_http_message, read_until_headers, redact_headers, scrub_request_target, should_close,
+        write_response,
     },
     pac::build_pac,
     terminal::{print_runtime_panel, print_trace_event},
@@ -356,6 +357,7 @@ impl RelayProxy {
             let request_started_at = Utc::now();
             let request_started = Instant::now();
             let request_line = parse_request_line(&request.header_text);
+            let request_path = scrub_request_target(&request_line.path);
             let request_payload = build_http_payload(
                 &request.body,
                 &request.headers,
@@ -363,7 +365,7 @@ impl RelayProxy {
                 self.config.payload_body_bytes,
                 json!({
                     "method": request_line.method,
-                    "path": request_line.path,
+                    "path": request_path,
                     "headers": redact_headers(&request.headers),
                 }),
             );
@@ -391,7 +393,7 @@ impl RelayProxy {
                 app: &app,
                 host: &host,
                 method: &request_line.method,
-                path: &request_line.path,
+                path: &request_path,
                 request_headers: &request.headers,
                 request_payload: &request_payload,
                 response_payload: &response_payload,
@@ -401,7 +403,7 @@ impl RelayProxy {
                 "connection_event_id": event_id,
                 "event": "http_request",
                 "method": request_line.method,
-                "path": request_line.path,
+                "path": request_path,
                 "host": host,
                 "app": app,
                 "ai_match": is_ai_host(&host, &self.config),
@@ -419,7 +421,7 @@ impl RelayProxy {
                 "connection_event_id": event_id,
                 "event": "http_response",
                 "method": request_line.method,
-                "path": request_line.path,
+                "path": request_path,
                 "host": host,
                 "app": app,
                 "traffic_kind": classification.kind,
@@ -439,7 +441,7 @@ impl RelayProxy {
                         host: host.clone(),
                         app,
                         method: request_line.method.clone(),
-                        path: request_line.path.clone(),
+                        path: request_path.clone(),
                         started_at: request_started_at,
                         ended_at: Utc::now(),
                         request_payload,
@@ -452,7 +454,7 @@ impl RelayProxy {
                     &capture_event_id,
                     &event_id,
                     &host,
-                    &request_line.path,
+                    &request_path,
                     ingest,
                 )?;
             } else {
@@ -460,7 +462,7 @@ impl RelayProxy {
                     &capture_event_id,
                     &event_id,
                     &host,
-                    &request_line.path,
+                    &request_path,
                     &classification,
                 )?;
             }


### PR DESCRIPTION
## Security finding

Privacy posture conflicts with the MVP:

> Payload interception defaults on, with 8 KB local previews and up to 256 KB bodies sent to Gateway. The local root CA and private key live in the user's home directory. Header redaction is blacklist-based and misses other credential-bearing headers and query-string secrets.

## What changed

- Defaults fresh Relay installs to metadata-first behavior by disabling payload capture unless explicitly configured.
- Sets default preview/body byte limits to zero so request/response bodies are not locally previewed or forwarded to Gateway by default.
- Broadens redaction for auth/key/token/session/cookie-style header and event field names.
- Adds request-target query scrubbing and uses scrubbed paths in local events, traffic classification, and Gateway ingest metadata.
- Preserves explicit non-zero payload capture config for deployments that intentionally opt in.

## Validation

- Rebased/verified against `origin/main`; no merge conflicts.
- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- GitHub CI `test` is green.

## Notes

Screenshots/proof are intentionally not committed to the repository.
