### PR TITLE
Handle streaming protocol compatibility

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -8,6 +8,19 @@ use std::{
 use anyhow::{anyhow, Result};
 use rustls::{ClientConfig, RootCertStore, ServerConfig};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AlpnProtocol {
+    Http11,
+}
+
+impl AlpnProtocol {
+    fn wire_name(self) -> Vec<u8> {
+        match self {
+            Self::Http11 => b"http/1.1".to_vec(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct CertificateAuthority {
     pub cert_path: PathBuf,
@@ -72,7 +85,7 @@ pub fn server_tls_config(host: &str, ca_dir: &Path) -> Result<ServerConfig> {
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(certs, key)?;
-    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    config.alpn_protocols = vec![AlpnProtocol::Http11.wire_name()];
     Ok(config)
 }
 
@@ -82,7 +95,7 @@ pub fn client_tls_config() -> ClientConfig {
     let mut config = ClientConfig::builder()
         .with_root_certificates(roots)
         .with_no_client_auth();
-    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    config.alpn_protocols = vec![AlpnProtocol::Http11.wire_name()];
     config
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
 use serde_json::{json, Map, Value};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::config::normalize_host;
 
@@ -30,9 +31,75 @@ pub struct HttpMessage {
 }
 
 #[derive(Debug)]
+pub struct HttpHead {
+    pub raw_headers: Vec<u8>,
+    pub header_text: String,
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub struct HttpBody {
+    pub raw: Vec<u8>,
+    pub decoded: Vec<u8>,
+}
+
+#[derive(Debug)]
 pub struct RequestLine {
     pub method: String,
     pub path: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtocolCompatibilityMode {
+    BufferedCapture,
+    MetadataOnlyTunnel,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtocolCompatibilityReason {
+    Http1Buffered,
+    ServerSentEvents,
+    WebSocketUpgrade,
+    HttpUpgrade,
+}
+
+impl ProtocolCompatibilityReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Http1Buffered => "http1_buffered",
+            Self::ServerSentEvents => "server_sent_events",
+            Self::WebSocketUpgrade => "websocket_upgrade",
+            Self::HttpUpgrade => "http_upgrade",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ProtocolCompatibilityDecision {
+    pub mode: ProtocolCompatibilityMode,
+    pub reason: ProtocolCompatibilityReason,
+}
+
+impl ProtocolCompatibilityDecision {
+    pub fn buffered() -> Self {
+        Self {
+            mode: ProtocolCompatibilityMode::BufferedCapture,
+            reason: ProtocolCompatibilityReason::Http1Buffered,
+        }
+    }
+
+    pub fn metadata_only(reason: ProtocolCompatibilityReason) -> Self {
+        Self {
+            mode: ProtocolCompatibilityMode::MetadataOnlyTunnel,
+            reason,
+        }
+    }
+
+    pub fn is_metadata_only(self) -> bool {
+        self.mode == ProtocolCompatibilityMode::MetadataOnlyTunnel
+    }
 }
 
 pub async fn write_response<T>(
@@ -93,42 +160,70 @@ pub async fn read_http_message<T>(stream: &mut T) -> Result<Option<HttpMessage>>
 where
     T: AsyncRead + Unpin,
 {
-    let header = match read_until_headers(stream).await {
-        Ok(header) => header,
-        Err(_) => return Ok(None),
+    let head = match read_http_head(stream).await? {
+        Some(head) => head,
+        None => return Ok(None),
     };
-    let header_text = String::from_utf8_lossy(&header).to_string();
-    let headers = parse_headers(&header_text);
-    let mut raw_body = Vec::new();
-    let mut body = Vec::new();
-    if headers
-        .get("transfer-encoding")
-        .is_some_and(|value| value.to_ascii_lowercase().contains("chunked"))
-    {
-        let (raw, decoded) = read_chunked_body(stream).await?;
-        raw_body = raw;
-        body = decoded;
-    } else if let Some(content_length) = headers.get("content-length") {
-        let content_length = content_length
-            .parse::<usize>()
-            .context("invalid content-length")?;
-        body.resize(content_length, 0);
-        stream.read_exact(&mut body).await?;
-        raw_body = body.clone();
-    }
-    let mut raw = header;
-    raw.extend_from_slice(&raw_body);
+    let body = read_http_body(stream, &head.headers).await?;
+    let mut raw = head.raw_headers;
+    raw.extend_from_slice(&body.raw);
     Ok(Some(HttpMessage {
         raw,
-        header_text,
-        headers,
-        body,
+        header_text: head.header_text,
+        headers: head.headers,
+        body: body.decoded,
     }))
 }
 
-pub async fn copy_bidirectional_counted<T>(left: &mut T, right: &mut T) -> Result<(u64, u64)>
+pub async fn read_http_head<T>(stream: &mut T) -> Result<Option<HttpHead>>
 where
-    T: AsyncRead + AsyncWriteExt + Unpin,
+    T: AsyncRead + Unpin,
+{
+    let raw_headers = match read_until_headers(stream).await {
+        Ok(header) => header,
+        Err(_) => return Ok(None),
+    };
+    let header_text = String::from_utf8_lossy(&raw_headers).to_string();
+    let headers = parse_headers(&header_text);
+    Ok(Some(HttpHead {
+        raw_headers,
+        header_text,
+        headers,
+    }))
+}
+
+pub async fn read_http_body<T>(
+    stream: &mut T,
+    headers: &HashMap<String, String>,
+) -> Result<HttpBody>
+where
+    T: AsyncRead + Unpin,
+{
+    if has_chunked_transfer_encoding(headers) {
+        let (raw, decoded) = read_chunked_body(stream).await?;
+        return Ok(HttpBody { raw, decoded });
+    }
+    if let Some(content_length) = headers.get("content-length") {
+        let content_length = content_length
+            .parse::<usize>()
+            .context("invalid content-length")?;
+        let mut body = vec![0; content_length];
+        stream.read_exact(&mut body).await?;
+        return Ok(HttpBody {
+            raw: body.clone(),
+            decoded: body,
+        });
+    }
+    Ok(HttpBody {
+        raw: Vec::new(),
+        decoded: Vec::new(),
+    })
+}
+
+pub async fn copy_bidirectional_counted<L, R>(left: &mut L, right: &mut R) -> Result<(u64, u64)>
+where
+    L: AsyncRead + AsyncWrite + Unpin,
+    R: AsyncRead + AsyncWrite + Unpin,
 {
     Ok(tokio::io::copy_bidirectional(left, right).await?)
 }
@@ -217,6 +312,70 @@ pub fn should_close(headers: &HashMap<String, String>) -> bool {
     headers
         .get("connection")
         .is_some_and(|value| value.eq_ignore_ascii_case("close"))
+}
+
+pub fn request_protocol_decision(
+    headers: &HashMap<String, String>,
+) -> ProtocolCompatibilityDecision {
+    upgrade_protocol_decision(headers).unwrap_or_else(ProtocolCompatibilityDecision::buffered)
+}
+
+pub fn response_protocol_decision(
+    status_code: Option<u16>,
+    headers: &HashMap<String, String>,
+) -> ProtocolCompatibilityDecision {
+    if status_code == Some(101) {
+        return upgrade_protocol_decision(headers).unwrap_or_else(|| {
+            ProtocolCompatibilityDecision::metadata_only(ProtocolCompatibilityReason::HttpUpgrade)
+        });
+    }
+    if let Some(decision) = upgrade_protocol_decision(headers) {
+        return decision;
+    }
+    if is_server_sent_events(headers) {
+        return ProtocolCompatibilityDecision::metadata_only(
+            ProtocolCompatibilityReason::ServerSentEvents,
+        );
+    }
+    ProtocolCompatibilityDecision::buffered()
+}
+
+pub fn build_metadata_only_http_payload(
+    headers: &HashMap<String, String>,
+    extra: Value,
+    decision: ProtocolCompatibilityDecision,
+) -> Value {
+    let mut payload = match extra {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    };
+    payload.insert("body_bytes".into(), json!(0));
+    payload.insert("body".into(), Value::Null);
+    payload.insert(
+        "body_preview".into(),
+        json!(format!(
+            "[{} response body tunneled without capture]",
+            decision.reason.as_str()
+        )),
+    );
+    payload.insert("decoded_body_bytes".into(), json!(0));
+    payload.insert("body_truncated".into(), json!(false));
+    payload.insert("preview_truncated".into(), json!(false));
+    payload.insert("truncated".into(), json!(false));
+    payload.insert(
+        "body_unavailable_reason".into(),
+        json!(format!(
+            "{} body tunneled without capture",
+            decision.reason.as_str()
+        )),
+    );
+    payload.insert("capture_mode".into(), json!("metadata_only_tunnel"));
+    payload.insert(
+        "protocol_compatibility_reason".into(),
+        json!(decision.reason.as_str()),
+    );
+    payload.insert("headers".into(), redact_headers(headers));
+    Value::Object(payload)
 }
 
 pub fn redact_headers(headers: &HashMap<String, String>) -> Value {
@@ -370,6 +529,47 @@ fn parse_headers(header_text: &str) -> HashMap<String, String> {
         }
     }
     headers
+}
+
+fn upgrade_protocol_decision(
+    headers: &HashMap<String, String>,
+) -> Option<ProtocolCompatibilityDecision> {
+    if !header_contains_token(headers, "connection", "upgrade") {
+        return None;
+    }
+    if header_contains_token(headers, "upgrade", "websocket") {
+        Some(ProtocolCompatibilityDecision::metadata_only(
+            ProtocolCompatibilityReason::WebSocketUpgrade,
+        ))
+    } else {
+        Some(ProtocolCompatibilityDecision::metadata_only(
+            ProtocolCompatibilityReason::HttpUpgrade,
+        ))
+    }
+}
+
+fn is_server_sent_events(headers: &HashMap<String, String>) -> bool {
+    header_contains_token(headers, "content-type", "text/event-stream")
+        || (has_chunked_transfer_encoding(headers)
+            && headers.get("content-type").is_some_and(|content_type| {
+                let content_type = content_type.to_ascii_lowercase();
+                content_type.contains("text/event-stream")
+                    || content_type.contains("application/x-ndjson")
+                    || content_type.contains("application/json-seq")
+                    || content_type.contains("application/stream+json")
+            }))
+}
+
+fn has_chunked_transfer_encoding(headers: &HashMap<String, String>) -> bool {
+    header_contains_token(headers, "transfer-encoding", "chunked")
+}
+
+fn header_contains_token(headers: &HashMap<String, String>, key: &str, token: &str) -> bool {
+    headers.get(key).is_some_and(|value| {
+        value
+            .split([',', ';'])
+            .any(|part| part.trim().eq_ignore_ascii_case(token))
+    })
 }
 
 async fn read_chunked_body<T>(stream: &mut T) -> Result<(Vec<u8>, Vec<u8>)>
@@ -528,5 +728,76 @@ mod tests {
         );
         assert!(!scrubbed.contains("sk-secret"));
         assert!(!scrubbed.contains("abc"));
+    }
+
+    #[test]
+    fn request_protocol_decision_detects_websocket_upgrade() {
+        let headers = HashMap::from([
+            ("connection".to_string(), "keep-alive, Upgrade".to_string()),
+            ("upgrade".to_string(), "websocket".to_string()),
+        ]);
+
+        let decision = request_protocol_decision(&headers);
+
+        assert_eq!(decision.mode, ProtocolCompatibilityMode::MetadataOnlyTunnel);
+        assert_eq!(
+            decision.reason,
+            ProtocolCompatibilityReason::WebSocketUpgrade
+        );
+    }
+
+    #[test]
+    fn response_protocol_decision_tunnels_chunked_sse() {
+        let headers = HashMap::from([
+            ("transfer-encoding".to_string(), "chunked".to_string()),
+            (
+                "content-type".to_string(),
+                "text/event-stream; charset=utf-8".to_string(),
+            ),
+        ]);
+
+        let decision = response_protocol_decision(Some(200), &headers);
+
+        assert_eq!(decision.mode, ProtocolCompatibilityMode::MetadataOnlyTunnel);
+        assert_eq!(
+            decision.reason,
+            ProtocolCompatibilityReason::ServerSentEvents
+        );
+    }
+
+    #[test]
+    fn response_protocol_decision_allows_buffered_chunked_json() {
+        let headers = HashMap::from([
+            ("transfer-encoding".to_string(), "chunked".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]);
+
+        let decision = response_protocol_decision(Some(200), &headers);
+
+        assert_eq!(decision, ProtocolCompatibilityDecision::buffered());
+    }
+
+    #[test]
+    fn metadata_only_payload_does_not_claim_body_capture() {
+        let headers = HashMap::from([
+            ("transfer-encoding".to_string(), "chunked".to_string()),
+            ("content-type".to_string(), "text/event-stream".to_string()),
+        ]);
+        let decision = response_protocol_decision(Some(200), &headers);
+
+        let payload =
+            build_metadata_only_http_payload(&headers, json!({"status_code": 200}), decision);
+
+        assert_eq!(payload["capture_mode"], "metadata_only_tunnel");
+        assert_eq!(
+            payload["protocol_compatibility_reason"],
+            "server_sent_events"
+        );
+        assert_eq!(payload["body"], Value::Null);
+        assert_eq!(payload["body_bytes"], 0);
+        assert!(payload["body_unavailable_reason"]
+            .as_str()
+            .unwrap()
+            .contains("tunneled without capture"));
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -18,10 +18,11 @@ use crate::{
     events::{append_event, clear_events, read_events},
     gateway::{CaptureIngest, GatewayClient, IngestResult},
     http::{
-        build_http_payload, copy_bidirectional_counted, parse_connect_target, parse_limit,
-        parse_request_line, parse_response_status, parse_route, parse_start_line,
-        read_http_message, read_until_headers, redact_headers, scrub_request_target, should_close,
-        write_response,
+        build_http_payload, build_metadata_only_http_payload, copy_bidirectional_counted,
+        parse_connect_target, parse_limit, parse_request_line, parse_response_status, parse_route,
+        parse_start_line, read_http_body, read_http_head, read_http_message, read_until_headers,
+        redact_headers, request_protocol_decision, response_protocol_decision,
+        scrub_request_target, should_close, write_response, ProtocolCompatibilityDecision,
     },
     pac::build_pac,
     terminal::{print_runtime_panel, print_trace_event},
@@ -358,6 +359,7 @@ impl RelayProxy {
             let request_started = Instant::now();
             let request_line = parse_request_line(&request.header_text);
             let request_path = scrub_request_target(&request_line.path);
+            let request_protocol = request_protocol_decision(&request.headers);
             let request_payload = build_http_payload(
                 &request.body,
                 &request.headers,
@@ -372,20 +374,116 @@ impl RelayProxy {
             upstream_tls.write_all(&request.raw).await?;
             upstream_tls.flush().await?;
 
-            let response = match read_http_message(&mut upstream_tls).await? {
-                Some(message) => message,
+            let response_head = match read_http_head(&mut upstream_tls).await? {
+                Some(head) => head,
                 None => break,
             };
-            bytes_in += response.raw.len();
-            let status_code = parse_response_status(&response.header_text);
+            bytes_in += response_head.raw_headers.len();
+            let status_code = parse_response_status(&response_head.header_text);
+            let response_protocol = response_protocol_decision(status_code, &response_head.headers);
+
+            if request_protocol.is_metadata_only() || response_protocol.is_metadata_only() {
+                let tunnel_decision = metadata_tunnel_decision(request_protocol, response_protocol);
+                let response_payload = build_metadata_only_http_payload(
+                    &response_head.headers,
+                    json!({
+                        "status_code": status_code,
+                    }),
+                    tunnel_decision,
+                );
+                let app = classify_host(&host, &self.config);
+                let classification = classify_captured_traffic(CapturedTraffic {
+                    app: &app,
+                    host: &host,
+                    method: &request_line.method,
+                    path: &request_path,
+                    request_headers: &request.headers,
+                    request_payload: &request_payload,
+                    response_payload: &response_payload,
+                });
+                self.log_event(json!({
+                    "event_id": capture_event_id,
+                    "connection_event_id": event_id,
+                    "event": "http_request",
+                    "method": request_line.method,
+                    "path": request_path,
+                    "host": host,
+                    "app": app,
+                    "ai_match": is_ai_host(&host, &self.config),
+                    "notion_match": is_notion_host(&host, &self.config),
+                    "traffic_kind": classification.kind,
+                    "traffic_reason": classification.reason,
+                    "collector_eligible": false,
+                    "capture_mode": "metadata_only_tunnel",
+                    "protocol_compatibility_reason": tunnel_decision.reason.as_str(),
+                    "headers": redact_headers(&request.headers),
+                    "request_bytes": request.body.len(),
+                    "request_preview": request_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
+                    "request_truncated": request_payload.get("preview_truncated").cloned().unwrap_or(Value::Bool(false)),
+                }))?;
+                self.log_event(json!({
+                    "event_id": capture_event_id,
+                    "connection_event_id": event_id,
+                    "event": "http_response",
+                    "method": request_line.method,
+                    "path": request_path,
+                    "host": host,
+                    "app": app,
+                    "traffic_kind": classification.kind,
+                    "traffic_reason": classification.reason,
+                    "collector_eligible": false,
+                    "capture_mode": "metadata_only_tunnel",
+                    "protocol_compatibility_reason": tunnel_decision.reason.as_str(),
+                    "status_code": status_code,
+                    "headers": redact_headers(&response_head.headers),
+                    "response_bytes": 0,
+                    "response_preview": response_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
+                    "response_truncated": false,
+                }))?;
+                self.log_collector_skipped(
+                    &capture_event_id,
+                    &event_id,
+                    &host,
+                    &request_path,
+                    &classification,
+                )?;
+                client_tls.write_all(&response_head.raw_headers).await?;
+                client_tls.flush().await?;
+                let (tunnel_bytes_out, tunnel_bytes_in) =
+                    copy_bidirectional_counted(&mut client_tls, &mut upstream_tls).await?;
+                bytes_out += tunnel_bytes_out as usize;
+                bytes_in += tunnel_bytes_in as usize;
+                self.log_event(json!({
+                    "event_id": capture_event_id,
+                    "connection_event_id": event_id,
+                    "event": "protocol_tunnel_closed",
+                    "method": request_line.method,
+                    "path": request_path,
+                    "host": host,
+                    "app": app,
+                    "duration_ms": request_started.elapsed().as_millis() as u64,
+                    "bytes_out": tunnel_bytes_out,
+                    "bytes_in": tunnel_bytes_in,
+                    "capture_mode": "metadata_only_tunnel",
+                    "protocol_compatibility_reason": tunnel_decision.reason.as_str(),
+                }))?;
+                break;
+            }
+
+            let response_body = read_http_body(&mut upstream_tls, &response_head.headers).await?;
+            bytes_in += response_body.raw.len();
+            let mut response_raw = response_head.raw_headers;
+            response_raw.extend_from_slice(&response_body.raw);
             let response_payload = build_http_payload(
-                &response.body,
-                &response.headers,
+                &response_body.decoded,
+                &response_head.headers,
                 self.config.payload_preview_bytes,
                 self.config.payload_body_bytes,
                 json!({
                     "status_code": status_code,
-                    "headers": redact_headers(&response.headers),
+                    "headers": redact_headers(&response_head.headers),
+                    "capture_mode": "buffered_capture",
+                    "protocol_compatibility_reason": response_protocol.reason.as_str(),
                 }),
             );
             let app = classify_host(&host, &self.config);
@@ -411,6 +509,8 @@ impl RelayProxy {
                 "traffic_kind": classification.kind,
                 "traffic_reason": classification.reason,
                 "collector_eligible": classification.is_ai_request(),
+                "capture_mode": "buffered_capture",
+                "protocol_compatibility_reason": response_protocol.reason.as_str(),
                 "headers": redact_headers(&request.headers),
                 "request_bytes": request.body.len(),
                 "request_preview": request_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
@@ -428,8 +528,10 @@ impl RelayProxy {
                 "traffic_reason": classification.reason,
                 "collector_eligible": classification.is_ai_request(),
                 "status_code": status_code,
-                "headers": redact_headers(&response.headers),
-                "response_bytes": response.body.len(),
+                "capture_mode": "buffered_capture",
+                "protocol_compatibility_reason": response_protocol.reason.as_str(),
+                "headers": redact_headers(&response_head.headers),
+                "response_bytes": response_body.decoded.len(),
                 "response_preview": response_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
                 "response_truncated": response_payload.get("preview_truncated").cloned().unwrap_or(Value::Bool(false)),
             }))?;
@@ -467,10 +569,10 @@ impl RelayProxy {
                 )?;
             }
 
-            client_tls.write_all(&response.raw).await?;
+            client_tls.write_all(&response_raw).await?;
             client_tls.flush().await?;
 
-            if should_close(&request.headers) || should_close(&response.headers) {
+            if should_close(&request.headers) || should_close(&response_head.headers) {
                 break;
             }
         }
@@ -570,5 +672,16 @@ impl RelayProxy {
     fn log_event(&self, event: Value) -> Result<()> {
         print_trace_event(&event);
         append_event(&self.config.log_path, event)
+    }
+}
+
+fn metadata_tunnel_decision(
+    request: ProtocolCompatibilityDecision,
+    response: ProtocolCompatibilityDecision,
+) -> ProtocolCompatibilityDecision {
+    if request.is_metadata_only() {
+        request
+    } else {
+        response
     }
 }


### PR DESCRIPTION
## Security finding

Protocol incompatibility:

> TLS is forced to HTTP/1.1. Chunked responses are fully buffered before forwarding, so SSE can stall indefinitely; WebSocket connections never transition to a frame tunnel; HTTP/2, standard gRPC, HTTP/3, and QUIC are unsupported.

## What changed

- Adds typed protocol compatibility decisions for buffered capture versus metadata-only tunnel handling.
- Detects WebSocket/HTTP upgrade traffic and known streaming responses such as chunked `text/event-stream` before buffering response bodies.
- For streaming/upgrade flows, forwards response headers immediately and switches to a bidirectional metadata-only tunnel so Relay does not stall or claim full body capture.
- Keeps non-streaming chunked JSON on the existing buffered capture path.
- Makes protocol behavior explicit in logs/events instead of silently corrupting or stalling unsupported flows.

## Validation

- Rebased/verified against `origin/main`; no merge conflicts.
- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- GitHub CI `test` is green.

## Notes

Screenshots/proof are intentionally not committed to the repository.
