### PR TITLE
Harden Relay install and uninstall management

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ truncated and headers are redacted.
 
 ## Install
 
+Production deployments should pin the source tag and verify the source archive:
+
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/src/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm-relay/main/src/install.sh | \
+  RELAY_VERSION=v0.1.0 \
+  RELAY_SHA256=<release-tarball-sha256> \
+  bash
 ```
 
 Then open a new terminal and run:
@@ -47,3 +52,8 @@ Then open a new terminal and run:
 relay
 ```
 
+For local development from a checked-out repository:
+
+```bash
+./src/install.sh --skip-trust-ca
+```

--- a/src/install.sh
+++ b/src/install.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 RELAY_HOME="${RELAY_HOME:-$HOME/.litellm-relay}"
+RELAY_VERSION="${RELAY_VERSION:-}"
+RELAY_SHA256="${RELAY_SHA256:-}"
+RELAY_SOURCE_URL="${RELAY_SOURCE_URL:-}"
+RELAY_ALLOW_UNPINNED_MAIN="${RELAY_ALLOW_UNPINNED_MAIN:-0}"
+RELAY_TRUST_CA="${RELAY_TRUST_CA:-1}"
 RELAY_PORT="4142"
 NETWORK_SERVICE=""
 BACKGROUND_SERVICE=0
@@ -14,18 +19,28 @@ usage() {
 Install LiteLLM Relay on macOS.
 
 Usage:
-  ./src/install.sh [--background] [--set-system-proxy "Wi-Fi"] [--gateway-url URL] [--api-key KEY]
+  ./src/install.sh [--version VERSION] [--sha256 SHA256] [--background]
+                   [--set-system-proxy "Wi-Fi"] [--gateway-url URL] [--api-key KEY]
 
 Options:
+  --version VERSION               Download and build the named GitHub release tag
+  --sha256 SHA256                 Verify the downloaded source archive checksum
+  --source-url URL                Download source from an explicit archive URL
+  --allow-unpinned-main           Allow remote install from mutable main.tar.gz
+  --skip-trust-ca                 Install without adding the Relay CA to login keychain
   --background                    Configure Gateway auth and start the LaunchAgent
   --set-system-proxy "Wi-Fi"      Route the named macOS network service through Relay
   --gateway-url URL               Gateway URL for non-interactive setup
   --api-key KEY                   Gateway key for non-interactive setup
   --bin-dir DIR                   Install relay shims into DIR
 
-By default this builds the Rust Relay binary, installs the relay command, and
-trusts the Relay local CA in your login keychain so AI app payloads can be
-captured. Then run:
+When run from a checked-out repository, this builds the local source tree.
+When run as a standalone remote script, pass RELAY_VERSION/--version or
+RELAY_SOURCE_URL/--source-url. Mutable main.tar.gz installs require the explicit
+RELAY_ALLOW_UNPINNED_MAIN=1 or --allow-unpinned-main opt-in.
+
+By default this installs the relay command and trusts the Relay local CA in your
+login keychain so AI app payloads can be captured. Then run:
 
   relay
 
@@ -37,29 +52,70 @@ Pass --set-system-proxy "Wi-Fi" to route AI apps through the background service.
 
 Relay settings are stored in:
   ~/.litellm-relay/config.yaml
+
+Environment:
+  RELAY_VERSION                 Same as --version
+  RELAY_SHA256                  Same as --sha256
+  RELAY_SOURCE_URL              Same as --source-url
+  RELAY_ALLOW_UNPINNED_MAIN=1   Same as --allow-unpinned-main
+  RELAY_TRUST_CA=0              Same as --skip-trust-ca
 USAGE
+}
+
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    echo "$1 requires a value" >&2
+    exit 2
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --version)
+      require_value "$1" "${2:-}"
+      RELAY_VERSION="$2"
+      shift 2
+      ;;
+    --sha256)
+      require_value "$1" "${2:-}"
+      RELAY_SHA256="$2"
+      shift 2
+      ;;
+    --source-url)
+      require_value "$1" "${2:-}"
+      RELAY_SOURCE_URL="$2"
+      shift 2
+      ;;
+    --allow-unpinned-main)
+      RELAY_ALLOW_UNPINNED_MAIN=1
+      shift
+      ;;
+    --skip-trust-ca)
+      RELAY_TRUST_CA=0
+      shift
+      ;;
     --background)
       BACKGROUND_SERVICE=1
       shift
       ;;
     --set-system-proxy)
+      require_value "$1" "${2:-}"
       NETWORK_SERVICE="${2:-}"
       BACKGROUND_SERVICE=1
       shift 2
       ;;
     --gateway-url)
+      require_value "$1" "${2:-}"
       SETUP_GATEWAY_URL="${2:-}"
       shift 2
       ;;
     --api-key)
+      require_value "$1" "${2:-}"
       SETUP_API_KEY="${2:-}"
       shift 2
       ;;
     --bin-dir)
+      require_value "$1" "${2:-}"
       INSTALL_BIN_DIR_OVERRIDE="${2:-}"
       shift 2
       ;;
@@ -74,6 +130,16 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -n "$RELAY_SHA256" && ! "$RELAY_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]]; then
+  echo "RELAY_SHA256 must be a 64-character SHA-256 hex digest." >&2
+  exit 2
+fi
+
+if [[ "$RELAY_TRUST_CA" != "0" && "$RELAY_TRUST_CA" != "1" ]]; then
+  echo "RELAY_TRUST_CA must be 0 or 1." >&2
+  exit 2
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "install.sh v0 currently supports macOS only." >&2
@@ -150,6 +216,75 @@ stop_legacy_python_relay() {
   done < <(lsof -tiTCP:"$RELAY_PORT" -sTCP:LISTEN 2>/dev/null || true)
 }
 
+verify_source_archive() {
+  local archive_path="$1"
+
+  if [[ -z "$RELAY_SHA256" ]]; then
+    cat >&2 <<WARN
+warning: no source archive checksum was provided.
+Set RELAY_SHA256 or pass --sha256 to make this install checksum-verified.
+WARN
+    return 0
+  fi
+
+  echo "Verifying source archive SHA-256..." >&2
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$RELAY_SHA256" "$archive_path" | shasum -a 256 -c - >&2
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$RELAY_SHA256" "$archive_path" | sha256sum -c - >&2
+  else
+    echo "shasum or sha256sum is required when RELAY_SHA256 is set." >&2
+    exit 1
+  fi
+}
+
+download_source_tree() {
+  local tmp_dir="$1"
+  local archive_path source_url source_root
+
+  archive_path="$tmp_dir/litellm-relay-source.tar.gz"
+  if [[ -n "$RELAY_SOURCE_URL" ]]; then
+    source_url="$RELAY_SOURCE_URL"
+  elif [[ -n "$RELAY_VERSION" ]]; then
+    source_url="https://github.com/BerriAI/litellm-relay/archive/refs/tags/$RELAY_VERSION.tar.gz"
+  elif [[ "$RELAY_ALLOW_UNPINNED_MAIN" == "1" ]]; then
+    source_url="https://github.com/BerriAI/litellm-relay/archive/refs/heads/main.tar.gz"
+    cat >&2 <<WARN
+warning: installing from mutable main because RELAY_ALLOW_UNPINNED_MAIN=1 was set.
+Prefer RELAY_VERSION plus RELAY_SHA256 for production deployments.
+WARN
+  else
+    cat >&2 <<ERROR
+Remote install requires a pinned source.
+
+Pass one of:
+  RELAY_VERSION=vX.Y.Z
+  --version vX.Y.Z
+  RELAY_SOURCE_URL=https://.../source.tar.gz
+
+For production, also set RELAY_SHA256 or pass --sha256.
+To intentionally build mutable main, rerun with --allow-unpinned-main.
+ERROR
+    exit 2
+  fi
+
+  echo "Downloading LiteLLM Relay source: $source_url" >&2
+  curl -fsSL "$source_url" -o "$archive_path"
+  verify_source_archive "$archive_path"
+
+  source_root="$(tar -tzf "$archive_path" | sed -n '1s#/.*##p')"
+  if [[ -z "$source_root" ]]; then
+    echo "source archive is empty or invalid." >&2
+    exit 1
+  fi
+  tar -xzf "$archive_path" -C "$tmp_dir"
+  if [[ ! -f "$tmp_dir/$source_root/Cargo.toml" ]]; then
+    echo "source archive did not contain Cargo.toml at the expected root." >&2
+    exit 1
+  fi
+  printf '%s\n' "$tmp_dir/$source_root"
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR=""
 if [[ -f "$SCRIPT_DIR/../Cargo.toml" ]]; then
@@ -159,9 +294,7 @@ elif [[ -f "$SCRIPT_DIR/Cargo.toml" ]]; then
 else
   TMP_DIR="$(mktemp -d)"
   trap 'rm -rf "$TMP_DIR"' EXIT
-  curl -fsSL "https://github.com/BerriAI/litellm-relay/archive/refs/heads/main.tar.gz" \
-    | tar -xz -C "$TMP_DIR"
-  BUILD_DIR="$TMP_DIR/litellm-relay-main"
+  BUILD_DIR="$(download_source_tree "$TMP_DIR")"
 fi
 
 if ! command -v cargo >/dev/null 2>&1; then
@@ -186,13 +319,21 @@ ln -sf "$RELAY_HOME/bin/litellm-relay" "$INSTALL_BIN_DIR/litellm-relay"
 install_path_entry "$INSTALL_BIN_DIR"
 
 CA_PATH="$("$RELAY_HOME/bin/litellm-relay" ca-path)"
-security add-trusted-cert -r trustRoot -k "$HOME/Library/Keychains/login.keychain-db" "$CA_PATH" >/dev/null 2>&1 || {
-  cat >&2 <<WARN
+if [[ "$RELAY_TRUST_CA" == "1" ]]; then
+  security add-trusted-cert -r trustRoot -k "$HOME/Library/Keychains/login.keychain-db" "$CA_PATH" >/dev/null 2>&1 || {
+    cat >&2 <<WARN
 warning: could not add the Relay CA to the login keychain.
 Payload capture requires trusting this certificate:
   $CA_PATH
 WARN
-}
+  }
+else
+  cat >&2 <<WARN
+Skipping Relay CA trust because RELAY_TRUST_CA=0 or --skip-trust-ca was set.
+Payload capture requires trusting this certificate later:
+  $CA_PATH
+WARN
+fi
 
 if [[ "$BACKGROUND_SERVICE" != "1" ]]; then
   cat <<DONE

--- a/src/install.sh
+++ b/src/install.sh
@@ -228,14 +228,28 @@ WARN
   fi
 
   echo "Verifying source archive SHA-256..." >&2
+  local actual_sha=""
   if command -v shasum >/dev/null 2>&1; then
-    printf '%s  %s\n' "$RELAY_SHA256" "$archive_path" | shasum -a 256 -c - >&2
+    actual_sha="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
   elif command -v sha256sum >/dev/null 2>&1; then
-    printf '%s  %s\n' "$RELAY_SHA256" "$archive_path" | sha256sum -c - >&2
+    actual_sha="$(sha256sum "$archive_path" | awk '{print $1}')"
   else
     echo "shasum or sha256sum is required when RELAY_SHA256 is set." >&2
     exit 1
   fi
+
+  local expected_lc actual_lc
+  expected_lc="$(printf '%s' "$RELAY_SHA256" | tr '[:upper:]' '[:lower:]')"
+  actual_lc="$(printf '%s' "$actual_sha" | tr '[:upper:]' '[:lower:]')"
+  if [[ -z "$actual_lc" || "$actual_lc" != "$expected_lc" ]]; then
+    cat >&2 <<MISMATCH
+source archive checksum mismatch; aborting install.
+  expected: $expected_lc
+  actual:   ${actual_lc:-<unavailable>}
+MISMATCH
+    exit 1
+  fi
+  echo "Source archive checksum verified." >&2
 }
 
 download_source_tree() {
@@ -294,7 +308,7 @@ elif [[ -f "$SCRIPT_DIR/Cargo.toml" ]]; then
 else
   TMP_DIR="$(mktemp -d)"
   trap 'rm -rf "$TMP_DIR"' EXIT
-  BUILD_DIR="$(download_source_tree "$TMP_DIR")"
+  BUILD_DIR="$(download_source_tree "$TMP_DIR")" || exit $?
 fi
 
 if ! command -v cargo >/dev/null 2>&1; then

--- a/src/uninstall.sh
+++ b/src/uninstall.sh
@@ -1,19 +1,221 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLIST="$HOME/Library/LaunchAgents/ai.litellm.relay.plist"
 RELAY_HOME="${RELAY_HOME:-$HOME/.litellm-relay}"
+INSTALL_BIN_DIR_OVERRIDE=""
+REMOVE_BIN=1
+REMOVE_DATA=0
+REMOVE_CA_TRUST=0
+REMOVE_PAC_FILE=0
+NETWORK_SERVICE=""
+
+usage() {
+  cat <<'USAGE'
+Uninstall LiteLLM Relay from macOS.
+
+Usage:
+  ./src/uninstall.sh [--bin-dir DIR] [--keep-bin] [--remove-ca-trust]
+                     [--remove-pac-file] [--remove-data]
+                     [--unset-system-proxy "Wi-Fi"]
+
+Options:
+  --bin-dir DIR                  Also remove relay shims from DIR
+  --keep-bin                     Keep Relay shims and ~/.litellm-relay/bin
+  --remove-ca-trust              Remove Relay CA trust from the login keychain
+  --remove-pac-file              Remove ~/.litellm-relay/relay.pac
+  --remove-data                  Remove ~/.litellm-relay after other cleanup
+  --unset-system-proxy SERVICE   Turn off PAC auto-proxy for a network service
+  -h, --help                     Show this help
+
+Default behavior stops/removes the LaunchAgent and removes installed command
+shims plus the Relay binary. It intentionally preserves logs, config, CA files,
+keychain trust, and system proxy settings unless explicit flags are passed.
+USAGE
+}
+
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    echo "$1 requires a value" >&2
+    exit 2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bin-dir)
+      require_value "$1" "${2:-}"
+      INSTALL_BIN_DIR_OVERRIDE="$2"
+      shift 2
+      ;;
+    --keep-bin)
+      REMOVE_BIN=0
+      shift
+      ;;
+    --remove-ca-trust)
+      REMOVE_CA_TRUST=1
+      shift
+      ;;
+    --remove-pac-file)
+      REMOVE_PAC_FILE=1
+      shift
+      ;;
+    --remove-data)
+      REMOVE_DATA=1
+      REMOVE_PAC_FILE=1
+      shift
+      ;;
+    --unset-system-proxy)
+      require_value "$1" "${2:-}"
+      NETWORK_SERVICE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "uninstall.sh v0 currently supports macOS only." >&2
+  exit 1
+fi
+
+PLIST="$HOME/Library/LaunchAgents/ai.litellm.relay.plist"
+RELAY_BINARY="$RELAY_HOME/bin/litellm-relay"
+RELAY_RUNNER="$RELAY_HOME/bin/run-relay"
+CA_PATH="$RELAY_HOME/mitm/litellm-relay-ca.pem"
+PAC_PATH="$RELAY_HOME/relay.pac"
+
+remove_owned_shim() {
+  local shim_path="$1"
+  local target
+
+  if [[ ! -e "$shim_path" && ! -L "$shim_path" ]]; then
+    return 0
+  fi
+
+  if [[ -L "$shim_path" ]]; then
+    target="$(readlink "$shim_path")"
+    case "$target" in
+      "$RELAY_BINARY"|"$RELAY_RUNNER"|"$RELAY_HOME"/bin/*)
+        rm -f "$shim_path"
+        echo "Removed shim: $shim_path"
+        ;;
+      *)
+        echo "Skipping non-Relay shim: $shim_path -> $target" >&2
+        ;;
+    esac
+    return 0
+  fi
+
+  echo "Skipping non-symlink path: $shim_path" >&2
+}
+
+remove_relay_bins() {
+  local bin_dir
+  local -a candidate_dirs=()
+
+  if [[ -n "$INSTALL_BIN_DIR_OVERRIDE" ]]; then
+    candidate_dirs+=("$INSTALL_BIN_DIR_OVERRIDE")
+  fi
+  candidate_dirs+=("/usr/local/bin" "/opt/homebrew/bin" "$HOME/.local/bin")
+
+  for bin_dir in "${candidate_dirs[@]}"; do
+    remove_owned_shim "$bin_dir/relay"
+    remove_owned_shim "$bin_dir/litellm-relay"
+  done
+
+  rm -f "$RELAY_RUNNER" "$RELAY_BINARY"
+  rmdir "$RELAY_HOME/bin" >/dev/null 2>&1 || true
+}
+
+remove_relay_data() {
+  case "$RELAY_HOME" in
+    ""|"/"|"$HOME"|"$HOME/")
+      echo "refusing to remove unsafe RELAY_HOME: $RELAY_HOME" >&2
+      exit 1
+      ;;
+  esac
+  rm -rf "$RELAY_HOME"
+}
+
+remove_ca_trust() {
+  if [[ ! -f "$CA_PATH" ]]; then
+    echo "Relay CA file not found at $CA_PATH; keychain trust was not changed."
+    return 0
+  fi
+
+  if security remove-trusted-cert -k "$HOME/Library/Keychains/login.keychain-db" "$CA_PATH" >/dev/null 2>&1; then
+    echo "Removed Relay CA trust from the login keychain."
+  else
+    cat >&2 <<WARN
+warning: could not remove Relay CA trust automatically.
+Check Keychain Access for:
+  LiteLLM Relay Local Root CA
+WARN
+  fi
+}
 
 launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1 || true
 rm -f "$PLIST"
 
+if [[ -n "$NETWORK_SERVICE" ]]; then
+  networksetup -setautoproxystate "$NETWORK_SERVICE" off
+  echo "Disabled PAC auto-proxy for network service: $NETWORK_SERVICE"
+fi
+
+if [[ "$REMOVE_CA_TRUST" == "1" ]]; then
+  remove_ca_trust
+fi
+
+if [[ "$REMOVE_PAC_FILE" == "1" ]]; then
+  rm -f "$PAC_PATH"
+fi
+
+if [[ "$REMOVE_BIN" == "1" ]]; then
+  remove_relay_bins
+fi
+
+if [[ "$REMOVE_DATA" == "1" ]]; then
+  remove_relay_data
+fi
+
 cat <<DONE
-LiteLLM Relay LaunchAgent removed.
+LiteLLM Relay uninstall complete.
 
-Relay data remains at:
-  $RELAY_HOME
-
-If you enabled a system PAC manually, disable it with:
-  networksetup -setautoproxystate "Wi-Fi" off
+Removed:
+  LaunchAgent: $PLIST
 DONE
 
+if [[ "$REMOVE_BIN" == "1" ]]; then
+  cat <<DONE
+  Relay shims and binary
+DONE
+else
+  cat <<DONE
+  Relay shims and binary were preserved because --keep-bin was set
+DONE
+fi
+
+if [[ "$REMOVE_DATA" == "1" ]]; then
+  cat <<DONE
+  Relay data: $RELAY_HOME
+DONE
+else
+  cat <<DONE
+
+Preserved:
+  Relay data: $RELAY_HOME
+
+Optional cleanup:
+  Remove CA trust:       ./src/uninstall.sh --remove-ca-trust
+  Remove Relay data:     ./src/uninstall.sh --remove-data
+  Disable system PAC:    ./src/uninstall.sh --unset-system-proxy "Wi-Fi"
+DONE
+fi


### PR DESCRIPTION
## Security finding

Not production-managed:

> Installation compiles mutable `main`, trusts a user-local CA, and creates a user LaunchAgent. There is no signed/notarized package, updater, rollback, central signed configuration, durable telemetry queue, complete uninstall, or tamper-resistant helper.

## What changed

- Requires standalone remote installs to use a pinned `RELAY_VERSION` / `--version` or an explicit `RELAY_SOURCE_URL`.
- Gates mutable `main.tar.gz` installs behind explicit `RELAY_ALLOW_UNPINNED_MAIN=1` / `--allow-unpinned-main`.
- Adds optional SHA-256 verification via `RELAY_SHA256` / `--sha256`.
- Adds `--skip-trust-ca` for installs that should not add the local Relay CA to the login keychain.
- Expands uninstall to remove the LaunchAgent plus Relay-owned shims/binary by default, while keeping logs/config/data, CA trust, PAC file, and system proxy state behind explicit cleanup flags.
- Documents production install pinning in `README.md`.

## Validation

- Rebased/verified against `origin/main`; no merge conflicts.
- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `bash -n src/install.sh src/uninstall.sh`
- `git diff --check`
- GitHub CI `test` is green.

## Notes

This PR is the first production-management hardening pass. Signed/notarized packaging, updater, central signed config, durable telemetry queue, and tamper-resistant helper can build on this pinned-install/uninstall foundation.

Screenshots/proof are intentionally not committed to the repository.
