### PR TITLE
Add typed relay attribution metadata

### DIFF
--- a/src/apps.rs
+++ b/src/apps.rs
@@ -29,6 +29,38 @@ pub struct AppMatchers {
     pub refs: Vec<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AppAttribution {
+    pub destination_app: String,
+    pub attribution_source: AttributionSource,
+    pub attribution_confidence: AttributionConfidence,
+    pub process_lookup_status: ProcessLookupStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_identity: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttributionSource {
+    KnownAppCatalog,
+    ConfiguredAiDomain,
+    Unmatched,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttributionConfidence {
+    High,
+    Medium,
+    None,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessLookupStatus {
+    NotAttempted,
+}
+
 static KNOWN_APPS: OnceLock<Vec<KnownApp>> = OnceLock::new();
 
 pub fn known_apps() -> &'static [KnownApp] {
@@ -67,6 +99,45 @@ pub fn classify_known_app(host: &str) -> Option<&'static str> {
         .map(|app| app.id.as_str())
 }
 
+pub fn classify_app_attribution(host: &str, ai_domains: &[String]) -> AppAttribution {
+    let normalized = normalize_host(host);
+    let (destination_app, attribution_source, attribution_confidence) =
+        if let Some(app_id) = classify_known_app(&normalized) {
+            (
+                app_id.to_string(),
+                AttributionSource::KnownAppCatalog,
+                AttributionConfidence::High,
+            )
+        } else if domain_matches_host(&normalized, ai_domains) {
+            (
+                "ai".to_string(),
+                AttributionSource::ConfiguredAiDomain,
+                AttributionConfidence::Medium,
+            )
+        } else {
+            (
+                "unknown".to_string(),
+                AttributionSource::Unmatched,
+                AttributionConfidence::None,
+            )
+        };
+
+    AppAttribution {
+        destination_app,
+        attribution_source,
+        attribution_confidence,
+        process_lookup_status: ProcessLookupStatus::NotAttempted,
+        process_identity: None,
+    }
+}
+
+pub fn domain_matches_host(host: &str, domains: &[String]) -> bool {
+    let normalized = normalize_host(host);
+    domains
+        .iter()
+        .any(|domain| normalized == *domain || normalized.ends_with(&format!(".{domain}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +147,63 @@ mod tests {
         assert_eq!(classify_known_app("www.notion.so"), Some("notion"));
         assert_eq!(classify_known_app("chat.openai.com"), Some("codex"));
         assert_eq!(classify_known_app("example.com"), None);
+    }
+
+    #[test]
+    fn should_attribute_known_destination_without_process_identity() {
+        let attribution = classify_app_attribution("api.openai.com", &[]);
+
+        assert_eq!(attribution.destination_app, "codex");
+        assert_eq!(
+            attribution.attribution_source,
+            AttributionSource::KnownAppCatalog
+        );
+        assert_eq!(
+            attribution.attribution_confidence,
+            AttributionConfidence::High
+        );
+        assert_eq!(
+            attribution.process_lookup_status,
+            ProcessLookupStatus::NotAttempted
+        );
+        assert_eq!(attribution.process_identity, None);
+    }
+
+    #[test]
+    fn should_attribute_configured_ai_destination_without_process_identity() {
+        let ai_domains = vec!["example.ai".to_string()];
+        let attribution = classify_app_attribution("api.example.ai", &ai_domains);
+
+        assert_eq!(attribution.destination_app, "ai");
+        assert_eq!(
+            attribution.attribution_source,
+            AttributionSource::ConfiguredAiDomain
+        );
+        assert_eq!(
+            attribution.attribution_confidence,
+            AttributionConfidence::Medium
+        );
+        assert_eq!(
+            attribution.process_lookup_status,
+            ProcessLookupStatus::NotAttempted
+        );
+        assert_eq!(attribution.process_identity, None);
+    }
+
+    #[test]
+    fn should_report_unknown_destination_and_unknown_process_status() {
+        let attribution = classify_app_attribution("example.com", &[]);
+
+        assert_eq!(attribution.destination_app, "unknown");
+        assert_eq!(attribution.attribution_source, AttributionSource::Unmatched);
+        assert_eq!(
+            attribution.attribution_confidence,
+            AttributionConfidence::None
+        );
+        assert_eq!(
+            attribution.process_lookup_status,
+            ProcessLookupStatus::NotAttempted
+        );
+        assert_eq!(attribution.process_identity, None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, path::PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::apps::{classify_known_app, default_ai_domains, default_notion_domains};
+use crate::apps::{default_ai_domains, default_notion_domains, domain_matches_host};
 use crate::system::home_dir;
 
 #[derive(Clone, Debug)]
@@ -213,29 +213,11 @@ pub fn normalize_host(host: &str) -> String {
 }
 
 pub fn is_ai_host(host: &str, config: &RelayConfig) -> bool {
-    is_domain_match(host, &config.ai_domains)
+    domain_matches_host(host, &config.ai_domains)
 }
 
 pub fn is_notion_host(host: &str, config: &RelayConfig) -> bool {
-    is_domain_match(host, &config.notion_domains)
-}
-
-pub fn classify_host(host: &str, config: &RelayConfig) -> String {
-    let normalized = normalize_host(host);
-    if let Some(app_id) = classify_known_app(&normalized) {
-        app_id.into()
-    } else if is_ai_host(&normalized, config) {
-        "ai".into()
-    } else {
-        "unknown".into()
-    }
-}
-
-fn is_domain_match(host: &str, domains: &[String]) -> bool {
-    let normalized = normalize_host(host);
-    domains
-        .iter()
-        .any(|domain| normalized == *domain || normalized.ends_with(&format!(".{domain}")))
+    domain_matches_host(host, &config.notion_domains)
 }
 
 fn load_legacy_env_settings() -> Result<Option<RelaySettings>> {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -10,7 +10,9 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
-use crate::{config::RelayConfig, system::hostname, traffic::TrafficClassification};
+use crate::{
+    apps::AppAttribution, config::RelayConfig, system::hostname, traffic::TrafficClassification,
+};
 
 pub struct GatewayClient {
     config: Arc<RelayConfig>,
@@ -88,48 +90,7 @@ impl GatewayClient {
                 error: Some("gateway.api_key is not set in config.yaml".into()),
             };
         };
-        let status_code = capture
-            .response_payload
-            .get("status_code")
-            .and_then(Value::as_u64);
-        let status = if status_code.is_some_and(|code| code >= 400) {
-            "failure"
-        } else {
-            "success"
-        };
-        let payload = json!({
-            "logs": [{
-                "request_id": format!("relay-{}", capture.event_id),
-                "call_type": "relay_capture",
-                "model": format!("{}-ai", if capture.app.is_empty() { "local-ai" } else { &capture.app }),
-                "api_base": format!("https://{}", capture.host),
-                "spend": 0,
-                "total_tokens": 0,
-                "prompt_tokens": 0,
-                "completion_tokens": 0,
-                "startTime": capture.started_at.to_rfc3339(),
-                "endTime": capture.ended_at.to_rfc3339(),
-                "request_duration_ms": capture.duration_ms,
-                "status": status,
-                "request_tags": ["litellm-relay", capture.app.as_str()],
-                "metadata": {
-                    "source": "litellm-relay",
-                    "runtime": "rust",
-                    "app": capture.app,
-                    "traffic_kind": capture.classification.kind,
-                    "traffic_reason": capture.classification.reason,
-                    "host": capture.host,
-                    "method": capture.method,
-                    "path": capture.path,
-                    "status_code": status_code,
-                    "device_id": hostname(),
-                    "local_user": std::env::var("USER").unwrap_or_default(),
-                    "relay_event_id": capture.event_id,
-                },
-                "proxy_server_request": capture.request_payload,
-                "response": capture.response_payload,
-            }]
-        });
+        let payload = build_collector_payload(&capture);
         match self
             .http_client
             .post(format!(
@@ -171,11 +132,62 @@ impl GatewayClient {
     }
 }
 
+fn build_collector_payload(capture: &CaptureIngest) -> Value {
+    let app = capture.attribution.destination_app.as_str();
+    let status_code = capture
+        .response_payload
+        .get("status_code")
+        .and_then(Value::as_u64);
+    let status = if status_code.is_some_and(|code| code >= 400) {
+        "failure"
+    } else {
+        "success"
+    };
+    json!({
+            "logs": [{
+                "request_id": format!("relay-{}", capture.event_id),
+                "call_type": "relay_capture",
+                "model": format!("{}-ai", if app.is_empty() { "local-ai" } else { app }),
+                "api_base": format!("https://{}", capture.host),
+                "spend": 0,
+                "total_tokens": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "startTime": capture.started_at.to_rfc3339(),
+                "endTime": capture.ended_at.to_rfc3339(),
+                "request_duration_ms": capture.duration_ms,
+                "status": status,
+                "request_tags": ["litellm-relay", app],
+                "metadata": {
+                    "source": "litellm-relay",
+                    "runtime": "rust",
+                    "app": app,
+                    "destination_app": app,
+                    "attribution_source": capture.attribution.attribution_source,
+                    "attribution_confidence": capture.attribution.attribution_confidence,
+                    "process_lookup_status": capture.attribution.process_lookup_status,
+                    "process_identity": capture.attribution.process_identity.as_deref(),
+                    "traffic_kind": capture.classification.kind,
+                    "traffic_reason": capture.classification.reason,
+                    "host": capture.host,
+                    "method": capture.method,
+                    "path": capture.path,
+                    "status_code": status_code,
+                    "device_id": hostname(),
+                    "local_user": std::env::var("USER").unwrap_or_default(),
+                    "relay_event_id": capture.event_id,
+                },
+                "proxy_server_request": capture.request_payload,
+                "response": capture.response_payload,
+            }]
+    })
+}
+
 #[derive(Debug)]
 pub struct CaptureIngest {
     pub event_id: String,
     pub host: String,
-    pub app: String,
+    pub attribution: AppAttribution,
     pub method: String,
     pub path: String,
     pub started_at: DateTime<Utc>,
@@ -232,4 +244,50 @@ fn build_shadow_payload(event: &Value, config: &RelayConfig, event_id: &str) -> 
             "timestamp": Utc::now().to_rfc3339(),
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+    use serde_json::json;
+
+    use super::*;
+    use crate::{
+        apps::classify_app_attribution,
+        traffic::{TrafficClassification, TrafficKind},
+    };
+
+    #[test]
+    fn should_include_destination_and_process_attribution_in_collector_metadata() {
+        let timestamp = DateTime::parse_from_rfc3339("2026-07-13T00:00:00Z")
+            .expect("timestamp should parse")
+            .with_timezone(&Utc);
+        let capture = CaptureIngest {
+            event_id: "event-1".into(),
+            host: "api.openai.com".into(),
+            attribution: classify_app_attribution("api.openai.com", &[]),
+            method: "POST".into(),
+            path: "/v1/responses".into(),
+            started_at: timestamp,
+            ended_at: timestamp,
+            request_payload: json!({"body_preview": "{\"model\":\"gpt-5\"}"}),
+            response_payload: json!({"status_code": 200}),
+            duration_ms: 25,
+            classification: TrafficClassification {
+                kind: TrafficKind::AiRequest,
+                reason: "openai_api_path",
+            },
+        };
+
+        let payload = build_collector_payload(&capture);
+        let metadata = &payload["logs"][0]["metadata"];
+
+        assert_eq!(metadata["app"], "codex");
+        assert_eq!(metadata["destination_app"], "codex");
+        assert_eq!(metadata["attribution_source"], "known_app_catalog");
+        assert_eq!(metadata["attribution_confidence"], "high");
+        assert_eq!(metadata["process_lookup_status"], "not_attempted");
+        assert!(metadata["process_identity"].is_null());
+        assert_eq!(metadata["traffic_reason"], "openai_api_path");
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -12,9 +12,9 @@ use tokio_rustls::{TlsAcceptor, TlsConnector};
 use uuid::Uuid;
 
 use crate::{
-    apps::known_apps,
+    apps::{classify_app_attribution, known_apps, AppAttribution},
     cert::{client_tls_config, ensure_ca, server_tls_config},
-    config::{classify_host, is_ai_host, is_notion_host, RelayConfig},
+    config::{is_ai_host, is_notion_host, RelayConfig},
     events::{append_event, clear_events, read_events},
     gateway::{CaptureIngest, GatewayClient, IngestResult},
     http::{
@@ -215,20 +215,22 @@ impl RelayProxy {
         let target = parse_connect_target(&target)?;
         let started_at = Instant::now();
         let event_id = Uuid::new_v4().to_string();
-        let app = classify_host(&target.host, &self.config);
+        let attribution = classify_app_attribution(&target.host, &self.config.ai_domains);
         let ai_match = is_ai_host(&target.host, &self.config);
         let notion_match = is_notion_host(&target.host, &self.config);
-        let mut event = json!({
-            "event_id": event_id,
-            "event": "connect",
-            "method": "CONNECT",
-            "host": target.host,
-            "port": target.port,
-            "peer": peer.to_string(),
-            "app": app,
-            "ai_match": ai_match,
-            "notion_match": notion_match,
-        });
+        let mut event = event_with_attribution(
+            json!({
+                "event_id": event_id,
+                "event": "connect",
+                "method": "CONNECT",
+                "host": target.host,
+                "port": target.port,
+                "peer": peer.to_string(),
+                "ai_match": ai_match,
+                "notion_match": notion_match,
+            }),
+            &attribution,
+        );
 
         if ai_match {
             event["shadow"] = self.gateway.maybe_shadow(&event).await;
@@ -264,19 +266,21 @@ impl RelayProxy {
             .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
             .await?;
         let (bytes_out, bytes_in) = copy_bidirectional_counted(&mut client, &mut upstream).await?;
-        self.log_event(json!({
-            "event_id": event_id,
-            "event": "connect_closed",
-            "method": "CONNECT",
-            "host": target.host,
-            "port": target.port,
-            "app": app,
-            "ai_match": ai_match,
-            "notion_match": notion_match,
-            "duration_ms": started_at.elapsed().as_millis() as u64,
-            "bytes_out": bytes_out,
-            "bytes_in": bytes_in,
-        }))?;
+        self.log_event(event_with_attribution(
+            json!({
+                "event_id": event_id,
+                "event": "connect_closed",
+                "method": "CONNECT",
+                "host": target.host,
+                "port": target.port,
+                "ai_match": ai_match,
+                "notion_match": notion_match,
+                "duration_ms": started_at.elapsed().as_millis() as u64,
+                "bytes_out": bytes_out,
+                "bytes_in": bytes_in,
+            }),
+            &attribution,
+        ))?;
         Ok(())
     }
 
@@ -391,7 +395,8 @@ impl RelayProxy {
                     }),
                     tunnel_decision,
                 );
-                let app = classify_host(&host, &self.config);
+                let attribution = classify_app_attribution(&host, &self.config.ai_domains);
+                let app = attribution.destination_app.clone();
                 let classification = classify_captured_traffic(CapturedTraffic {
                     app: &app,
                     host: &host,
@@ -401,14 +406,13 @@ impl RelayProxy {
                     request_payload: &request_payload,
                     response_payload: &response_payload,
                 });
-                self.log_event(json!({
+                self.log_event(event_with_attribution(json!({
                     "event_id": capture_event_id,
                     "connection_event_id": event_id,
                     "event": "http_request",
                     "method": request_line.method,
                     "path": request_path,
                     "host": host,
-                    "app": app,
                     "ai_match": is_ai_host(&host, &self.config),
                     "notion_match": is_notion_host(&host, &self.config),
                     "traffic_kind": classification.kind,
@@ -420,15 +424,14 @@ impl RelayProxy {
                     "request_bytes": request.body.len(),
                     "request_preview": request_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
                     "request_truncated": request_payload.get("preview_truncated").cloned().unwrap_or(Value::Bool(false)),
-                }))?;
-                self.log_event(json!({
+                }), &attribution))?;
+                self.log_event(event_with_attribution(json!({
                     "event_id": capture_event_id,
                     "connection_event_id": event_id,
                     "event": "http_response",
                     "method": request_line.method,
                     "path": request_path,
                     "host": host,
-                    "app": app,
                     "traffic_kind": classification.kind,
                     "traffic_reason": classification.reason,
                     "collector_eligible": false,
@@ -439,12 +442,13 @@ impl RelayProxy {
                     "response_bytes": 0,
                     "response_preview": response_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
                     "response_truncated": false,
-                }))?;
+                }), &attribution))?;
                 self.log_collector_skipped(
                     &capture_event_id,
                     &event_id,
                     &host,
                     &request_path,
+                    &attribution,
                     &classification,
                 )?;
                 client_tls.write_all(&response_head.raw_headers).await?;
@@ -453,20 +457,22 @@ impl RelayProxy {
                     copy_bidirectional_counted(&mut client_tls, &mut upstream_tls).await?;
                 bytes_out += tunnel_bytes_out as usize;
                 bytes_in += tunnel_bytes_in as usize;
-                self.log_event(json!({
-                    "event_id": capture_event_id,
-                    "connection_event_id": event_id,
-                    "event": "protocol_tunnel_closed",
-                    "method": request_line.method,
-                    "path": request_path,
-                    "host": host,
-                    "app": app,
-                    "duration_ms": request_started.elapsed().as_millis() as u64,
-                    "bytes_out": tunnel_bytes_out,
-                    "bytes_in": tunnel_bytes_in,
-                    "capture_mode": "metadata_only_tunnel",
-                    "protocol_compatibility_reason": tunnel_decision.reason.as_str(),
-                }))?;
+                self.log_event(event_with_attribution(
+                    json!({
+                        "event_id": capture_event_id,
+                        "connection_event_id": event_id,
+                        "event": "protocol_tunnel_closed",
+                        "method": request_line.method,
+                        "path": request_path,
+                        "host": host,
+                        "duration_ms": request_started.elapsed().as_millis() as u64,
+                        "bytes_out": tunnel_bytes_out,
+                        "bytes_in": tunnel_bytes_in,
+                        "capture_mode": "metadata_only_tunnel",
+                        "protocol_compatibility_reason": tunnel_decision.reason.as_str(),
+                    }),
+                    &attribution,
+                ))?;
                 break;
             }
 
@@ -486,7 +492,8 @@ impl RelayProxy {
                     "protocol_compatibility_reason": response_protocol.reason.as_str(),
                 }),
             );
-            let app = classify_host(&host, &self.config);
+            let attribution = classify_app_attribution(&host, &self.config.ai_domains);
+            let app = attribution.destination_app.clone();
             let classification = classify_captured_traffic(CapturedTraffic {
                 app: &app,
                 host: &host,
@@ -496,14 +503,13 @@ impl RelayProxy {
                 request_payload: &request_payload,
                 response_payload: &response_payload,
             });
-            self.log_event(json!({
+            self.log_event(event_with_attribution(json!({
                 "event_id": capture_event_id,
                 "connection_event_id": event_id,
                 "event": "http_request",
                 "method": request_line.method,
                 "path": request_path,
                 "host": host,
-                "app": app,
                 "ai_match": is_ai_host(&host, &self.config),
                 "notion_match": is_notion_host(&host, &self.config),
                 "traffic_kind": classification.kind,
@@ -515,15 +521,14 @@ impl RelayProxy {
                 "request_bytes": request.body.len(),
                 "request_preview": request_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
                 "request_truncated": request_payload.get("preview_truncated").cloned().unwrap_or(Value::Bool(false)),
-            }))?;
-            self.log_event(json!({
+            }), &attribution))?;
+            self.log_event(event_with_attribution(json!({
                 "event_id": capture_event_id,
                 "connection_event_id": event_id,
                 "event": "http_response",
                 "method": request_line.method,
                 "path": request_path,
                 "host": host,
-                "app": app,
                 "traffic_kind": classification.kind,
                 "traffic_reason": classification.reason,
                 "collector_eligible": classification.is_ai_request(),
@@ -534,14 +539,14 @@ impl RelayProxy {
                 "response_bytes": response_body.decoded.len(),
                 "response_preview": response_payload.get("body_preview").cloned().unwrap_or(Value::String(String::new())),
                 "response_truncated": response_payload.get("preview_truncated").cloned().unwrap_or(Value::Bool(false)),
-            }))?;
+            }), &attribution))?;
             if classification.is_ai_request() {
                 let ingest = self
                     .gateway
                     .ingest_capture(CaptureIngest {
                         event_id: capture_event_id.clone(),
                         host: host.clone(),
-                        app,
+                        attribution: attribution.clone(),
                         method: request_line.method.clone(),
                         path: request_path.clone(),
                         started_at: request_started_at,
@@ -557,6 +562,7 @@ impl RelayProxy {
                     &event_id,
                     &host,
                     &request_path,
+                    &attribution,
                     ingest,
                 )?;
             } else {
@@ -565,6 +571,7 @@ impl RelayProxy {
                     &event_id,
                     &host,
                     &request_path,
+                    &attribution,
                     &classification,
                 )?;
             }
@@ -579,20 +586,23 @@ impl RelayProxy {
 
         let _ = upstream_tls.shutdown().await;
         let _ = client_tls.shutdown().await;
-        self.log_event(json!({
-            "event_id": event_id,
-            "event": "connect_closed",
-            "method": "CONNECT",
-            "host": host,
-            "port": port,
-            "app": classify_host(&host, &self.config),
-            "ai_match": is_ai_host(&host, &self.config),
-            "notion_match": is_notion_host(&host, &self.config),
-            "capture_payloads": true,
-            "duration_ms": started_at.elapsed().as_millis() as u64,
-            "bytes_out": bytes_out,
-            "bytes_in": bytes_in,
-        }))?;
+        let attribution = classify_app_attribution(&host, &self.config.ai_domains);
+        self.log_event(event_with_attribution(
+            json!({
+                "event_id": event_id,
+                "event": "connect_closed",
+                "method": "CONNECT",
+                "host": host,
+                "port": port,
+                "ai_match": is_ai_host(&host, &self.config),
+                "notion_match": is_notion_host(&host, &self.config),
+                "capture_payloads": true,
+                "duration_ms": started_at.elapsed().as_millis() as u64,
+                "bytes_out": bytes_out,
+                "bytes_in": bytes_in,
+            }),
+            &attribution,
+        ))?;
         Ok(())
     }
 
@@ -623,6 +633,14 @@ impl RelayProxy {
             "gateway_url": self.config.gateway_url,
             "events_loaded": read_events(&self.config.log_path, 1000).len(),
             "known_apps": known_apps(),
+            "attribution": {
+                "destination_field": "destination_app",
+                "compatibility_field": "app",
+                "process_identity_field": "process_identity",
+                "process_lookup_status_field": "process_lookup_status",
+                "sources": ["known_app_catalog", "configured_ai_domain", "unmatched"],
+                "confidences": ["high", "medium", "none"],
+            },
             "runtime": "rust",
         }))
     }
@@ -633,20 +651,23 @@ impl RelayProxy {
         connection_event_id: &str,
         host: &str,
         path: &str,
+        attribution: &AppAttribution,
         ingest: IngestResult,
     ) -> Result<()> {
-        self.log_event(json!({
-            "event_id": capture_event_id,
-            "connection_event_id": connection_event_id,
-            "event": "collector_spend_logs",
-            "host": host,
-            "app": classify_host(host, &self.config),
-            "path": path,
-            "attempted": ingest.attempted,
-            "ok": ingest.ok,
-            "status": ingest.status,
-            "error": ingest.error,
-        }))
+        self.log_event(event_with_attribution(
+            json!({
+                "event_id": capture_event_id,
+                "connection_event_id": connection_event_id,
+                "event": "collector_spend_logs",
+                "host": host,
+                "path": path,
+                "attempted": ingest.attempted,
+                "ok": ingest.ok,
+                "status": ingest.status,
+                "error": ingest.error,
+            }),
+            attribution,
+        ))
     }
 
     fn log_collector_skipped(
@@ -655,18 +676,21 @@ impl RelayProxy {
         connection_event_id: &str,
         host: &str,
         path: &str,
+        attribution: &AppAttribution,
         classification: &TrafficClassification,
     ) -> Result<()> {
-        self.log_event(json!({
-            "event_id": capture_event_id,
-            "connection_event_id": connection_event_id,
-            "event": "collector_skipped",
-            "host": host,
-            "app": classify_host(host, &self.config),
-            "path": path,
-            "traffic_kind": classification.kind,
-            "traffic_reason": classification.reason,
-        }))
+        self.log_event(event_with_attribution(
+            json!({
+                "event_id": capture_event_id,
+                "connection_event_id": connection_event_id,
+                "event": "collector_skipped",
+                "host": host,
+                "path": path,
+                "traffic_kind": classification.kind,
+                "traffic_reason": classification.reason,
+            }),
+            attribution,
+        ))
     }
 
     fn log_event(&self, event: Value) -> Result<()> {
@@ -684,4 +708,39 @@ fn metadata_tunnel_decision(
     } else {
         response
     }
+}
+
+fn event_with_attribution(mut event: Value, attribution: &AppAttribution) -> Value {
+    if let Value::Object(map) = &mut event {
+        map.insert(
+            "app".into(),
+            Value::String(attribution.destination_app.clone()),
+        );
+        map.insert(
+            "destination_app".into(),
+            Value::String(attribution.destination_app.clone()),
+        );
+        map.insert(
+            "attribution_source".into(),
+            serde_json::to_value(attribution.attribution_source)
+                .expect("attribution source should serialize"),
+        );
+        map.insert(
+            "attribution_confidence".into(),
+            serde_json::to_value(attribution.attribution_confidence)
+                .expect("attribution confidence should serialize"),
+        );
+        map.insert(
+            "process_lookup_status".into(),
+            serde_json::to_value(attribution.process_lookup_status)
+                .expect("process lookup status should serialize"),
+        );
+        if let Some(process_identity) = &attribution.process_identity {
+            map.insert(
+                "process_identity".into(),
+                Value::String(process_identity.clone()),
+            );
+        }
+    }
+    event
 }

--- a/src/traffic.rs
+++ b/src/traffic.rs
@@ -87,16 +87,16 @@ pub fn classify_captured_traffic(capture: CapturedTraffic<'_>) -> TrafficClassif
         return TrafficClassification::telemetry("notion_realtime");
     }
 
-    if capture.app == "codex" && is_codex_ai_path(&path) {
-        return TrafficClassification::ai("codex_ai_path");
-    }
-
     if capture.app == "notion" && is_notion_ai_request(&path, &body_preview) {
         return TrafficClassification::ai("notion_ai_marker");
     }
 
     if is_openai_api_host(&host) && is_openai_ai_path(&path) {
         return TrafficClassification::ai("openai_api_path");
+    }
+
+    if capture.app == "codex" && is_codex_ai_path(&path) {
+        return TrafficClassification::ai("codex_ai_path");
     }
 
     if capture.method.eq_ignore_ascii_case("POST")
@@ -317,7 +317,7 @@ mod tests {
         ));
 
         assert!(classification.is_ai_request());
-        assert_eq!(classification.reason, "codex_ai_path");
+        assert_eq!(classification.reason, "openai_api_path");
     }
 
     #[test]


### PR DESCRIPTION
## Security finding

Coverage and attribution:

> Relay's PAC sends configured domains to localhost and everything else direct. "App" attribution is inferred from the destination hostname, so any program calling `api.openai.com` is labeled Codex; there is no bundle ID, PID, signing identity, or audit token. The built-in catalog contains only Notion and OpenAI-family entries.

## What changed

- Adds a typed attribution model that separates destination/catalog classification from process identity.
- Emits explicit attribution metadata on relay events and Gateway collector metadata: `destination_app`, `attribution_source`, `attribution_confidence`, `process_lookup_status`, and optional `process_identity`.
- Preserves the legacy `app` field as a compatibility destination label, while avoiding any claim that an `api.openai.com` hostname match is Codex process identity.
- Labels direct OpenAI API payload traffic with `openai_api_path` instead of a Codex-specific traffic reason.
- Adds focused tests for known catalog attribution, configured AI domains, unknown process status, and Gateway metadata.

## Validation

- Rebased/verified against `origin/main`; no merge conflicts.
- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- GitHub CI `test` is green.

## Notes

This PR makes attribution honest and typed. It does not claim full bundle ID/PID/signing/audit-token attribution yet; unresolved process identity is represented explicitly through `process_lookup_status`.

Screenshots/proof are intentionally not committed to the repository.
