### PR TITLE
Improve Relay CI and release maturity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.github/
+ui/node_modules/
+ui/dist/
+ui/.vite/
+*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,21 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  rust:
+    name: Rust checks (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15]
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -15,8 +27,70 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Format
+        if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --all --check
       - name: Test
         run: cargo test
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
+
+  shell:
+    name: Installer shell checks
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate installer scripts
+        run: bash -n src/install.sh src/uninstall.sh
+      - name: Check installer help path
+        run: bash src/install.sh --help
+
+  proxy-smoke:
+    name: Proxy/TLS smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build relay
+        run: cargo build
+      - name: Run CONNECT/TLS smoke test
+        run: ./scripts/ci/proxy_smoke.sh
+
+  protocol-regression:
+    name: Protocol regression tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run streaming and upgrade tests
+        run: |
+          cargo test request_protocol_decision_detects_websocket_upgrade
+          cargo test response_protocol_decision_tunnels_chunked_sse
+          cargo test metadata_only_payload_does_not_claim_body_capture
+
+  security-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Audit dependencies
+        run: cargo audit --deny warnings
+
+  docker-build:
+    name: Docker image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: litellm-relay:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to package, for example v0.1.0"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  package-macos:
+    name: Package macOS binary (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            artifact: x86_64-apple-darwin
+          - os: macos-15
+            artifact: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build release binary
+        run: cargo build --release --locked
+      - name: Package artifact
+        env:
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          name="litellm-relay-${TAG_NAME}-${{ matrix.artifact }}"
+          mkdir -p "dist/$name"
+          cp target/release/litellm-relay "dist/$name/"
+          cp README.md LICENSE "dist/$name/"
+          tar -C dist -czf "dist/$name.tar.gz" "$name"
+          shasum -a 256 "dist/$name.tar.gz" > "dist/$name.tar.gz.sha256"
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: litellm-relay-${{ matrix.artifact }}
+          path: dist/*
+
+  docker:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/litellm-labs/litellm-relay
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,13 +809,13 @@ name = "litellm-relay"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "brotli",
  "chrono",
  "clap",
  "flate2",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1176,15 +1176,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+base64 = "0.22"
 brotli = "7.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 flate2 = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["cookies", "json", "rustls-tls"] }
 rustls = "0.23"
-rustls-pemfile = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1-bookworm AS build
+
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release --locked
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/target/release/litellm-relay /usr/local/bin/litellm-relay
+
+EXPOSE 4142
+ENTRYPOINT ["litellm-relay"]
+CMD ["serve"]

--- a/docs/conformance-matrix.md
+++ b/docs/conformance-matrix.md
@@ -1,0 +1,22 @@
+# Relay Conformance Matrix
+
+This matrix tracks the minimum gates required before calling LiteLLM Relay production-ready.
+
+| Area | CI status | Current gate | Remaining manual or future gate |
+| --- | --- | --- | --- |
+| Formatting | Automated | `cargo fmt --all --check` on Ubuntu | None |
+| Rust unit tests | Automated | `cargo test` on Ubuntu and macOS | Expand provider/app fixtures as catalog grows |
+| Clippy | Automated | `cargo clippy --all-targets -- -D warnings` on Ubuntu and macOS | None |
+| macOS deployment basics | Automated | macOS test job plus installer shell syntax/help checks | Signed/notarized package install on managed device |
+| Proxy CONNECT/TLS | Automated | `scripts/ci/proxy_smoke.sh` starts Relay and tunnels HTTPS through CONNECT | MITM capture against a controlled HTTPS upstream |
+| Streaming and WebSocket handling | Automated | Focused Rust regression tests for SSE and WebSocket upgrade decisions | Browser-level WebSocket and SSE end-to-end screenshots |
+| Privacy defaults and redaction | Automated | Unit tests for metadata-only defaults, header redaction, query scrubbing, body suppression | Gateway-side audit of ingested metadata |
+| Attribution | Automated | Unit tests for catalog attribution, configured AI domains, unknown process status, Gateway metadata | macOS process identity lookup with bundle ID/PID/signing identity |
+| Installer management | Automated | `bash -n`, installer help path, release pinning logic in unit-free shell checks | MDM deployment dry run, rollback, full uninstall on disposable macOS account |
+| Security dependencies | Automated | `cargo audit --deny warnings` | Static analysis and secret scanning policy |
+| Docker image | Automated | PR CI builds image without push; tag release publishes GHCR image | Runtime support statement for Linux container usage |
+| Netskope / enterprise network | Manual | Not covered in CI | Validate PAC/proxy behavior behind Netskope or equivalent enterprise TLS inspection |
+| Performance | Manual | Not covered in CI | Throughput/latency benchmark with representative AI traffic |
+| Release artifacts | Automated on tags | Release workflow packages macOS tarballs and publishes Docker image | Codesign/notarization and SBOM attachment |
+
+CI is not a substitute for the manual enterprise-network and macOS device-management gates, but it prevents regressions in the core Rust, proxy, privacy, and packaging surfaces before release.

--- a/docs/formal-release-announcement.md
+++ b/docs/formal-release-announcement.md
@@ -1,0 +1,34 @@
+# Feedback requested: formal LiteLLM Relay release
+
+We are preparing a formal `v0.1.0` release of LiteLLM Relay and want feedback from teams interested in piloting it.
+
+## Proposed scope
+
+- macOS pilot binary with pinned release artifacts.
+- Metadata-first capture defaults.
+- Gateway ingest metadata for AI traffic.
+- CONNECT/TLS smoke coverage in CI.
+- Streaming and WebSocket regression coverage.
+- Docker image for CI, demos, and Linux proxy experiments.
+- Documented conformance matrix and known limitations.
+
+## Not in the first release
+
+- Signed/notarized `.pkg`.
+- Central signed config and updater.
+- Durable telemetry queue.
+- Tamper-resistant helper.
+- Full PID, bundle ID, audit-token, and signing-identity attribution.
+- HTTP/2, gRPC, HTTP/3, and QUIC support.
+
+## Feedback requested
+
+Please comment with:
+
+- Whether you would pilot a scoped `v0.1.0`.
+- Required MDM or security-review gates.
+- Whether Docker images are useful for your testing workflow.
+- Enterprise-network constraints such as Netskope or other TLS inspection.
+- Any release artifact requirements before deployment.
+
+If there is enough interest, we will prioritize the formal release checklist and publish tagged artifacts.

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -1,0 +1,54 @@
+# LiteLLM Relay Release Plan
+
+## Goal
+
+Ship a formal `v0.1.0` release only after the relay has repeatable CI, macOS packaging artifacts, a documented conformance matrix, and a clear scope for what the first release does and does not guarantee.
+
+## Release scope
+
+- macOS local relay binary for pilot deployment.
+- PAC-driven CONNECT proxy path.
+- Metadata-first privacy defaults.
+- Gateway ingest metadata for AI traffic.
+- Explicit protocol handling for buffered HTTP/1.1, SSE-like streams, and WebSocket upgrades.
+- Installer support for pinned source archives and optional SHA-256 verification.
+
+## Release artifacts
+
+- `litellm-relay-v0.1.0-x86_64-apple-darwin.tar.gz`
+- `litellm-relay-v0.1.0-aarch64-apple-darwin.tar.gz`
+- SHA-256 files for each archive.
+- GitHub release notes with supported deployment assumptions.
+- GHCR Docker image: `ghcr.io/litellm-labs/litellm-relay:v0.1.0`
+
+The Docker image is for CI, demos, and Linux proxy experiments. It is not a replacement for macOS device deployment, because root CA trust, LaunchAgent behavior, MDM configuration, and process attribution are host-specific.
+
+## CI gates before tagging
+
+- Ubuntu and macOS Rust tests pass.
+- `cargo fmt --all --check` passes.
+- `cargo clippy --all-targets -- -D warnings` passes.
+- Installer scripts pass shell syntax checks.
+- Proxy/TLS smoke test passes.
+- Streaming and WebSocket protocol regression tests pass.
+- Dependency audit passes.
+- Docker image builds.
+
+## Manual gates before tagging
+
+- Verify install and uninstall on a disposable macOS user account.
+- Verify PAC behavior on a managed network profile.
+- Verify Gateway ingest metadata in a real LiteLLM Gateway.
+- Verify one representative SSE flow and one WebSocket flow with screenshots.
+- Validate behind Netskope or an equivalent enterprise TLS/proxy stack.
+- Record known limitations in the release notes.
+
+## Deferred beyond `v0.1.0`
+
+- Signed and notarized `.pkg`.
+- Durable updater and rollback.
+- Central signed configuration.
+- Durable telemetry queue.
+- Tamper-resistant privileged helper.
+- Full macOS process attribution with PID, bundle ID, audit token, and signing identity.
+- HTTP/2, gRPC, HTTP/3, and QUIC support.

--- a/scripts/ci/proxy_smoke.sh
+++ b/scripts/ci/proxy_smoke.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="${LITELLM_RELAY_BIN:-$ROOT/target/debug/litellm-relay}"
+
+if [[ ! -x "$BIN" ]]; then
+  cargo build --manifest-path "$ROOT/Cargo.toml"
+fi
+
+tmp_dir="$(mktemp -d)"
+relay_pid=""
+tls_pid=""
+
+cleanup() {
+  if [[ -n "$relay_pid" ]]; then
+    kill "$relay_pid" >/dev/null 2>&1 || true
+    wait "$relay_pid" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$tls_pid" ]]; then
+    kill "$tls_pid" >/dev/null 2>&1 || true
+    wait "$tls_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind(("127.0.0.1", 0))
+    print(s.getsockname()[1])
+PY
+}
+
+relay_port="$(pick_port)"
+upstream_port="$(pick_port)"
+home_dir="$tmp_dir/home"
+relay_home="$home_dir/.litellm-relay"
+mkdir -p "$relay_home"
+
+cat > "$relay_home/config.yaml" <<YAML
+relay:
+  host: 127.0.0.1
+  port: $relay_port
+  log_path: $tmp_dir/relay.log.jsonl
+  mitm_ca_dir: $tmp_dir/mitm
+gateway:
+  url: http://127.0.0.1:4000
+shadow:
+  enabled: false
+capture:
+  payloads: false
+  payload_preview_bytes: 0
+  payload_body_bytes: 0
+domains:
+  notion: []
+  ai:
+    - api.openai.com
+timeouts:
+  request_seconds: 2.0
+YAML
+
+HOME="$home_dir" "$BIN" serve >"$tmp_dir/relay.out" 2>"$tmp_dir/relay.err" &
+relay_pid="$!"
+
+for _ in {1..60}; do
+  if curl -fs "http://127.0.0.1:$relay_port/api/status" >/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+curl -fsS "http://127.0.0.1:$relay_port/api/status" | grep -q '"runtime":"rust"'
+curl -fsS "http://127.0.0.1:$relay_port/proxy.pac" | grep -q "PROXY 127.0.0.1:$relay_port"
+
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -nodes \
+  -sha256 \
+  -days 1 \
+  -keyout "$tmp_dir/upstream.key" \
+  -out "$tmp_dir/upstream.crt" \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" >/dev/null 2>&1
+
+openssl s_server \
+  -quiet \
+  -accept "$upstream_port" \
+  -cert "$tmp_dir/upstream.crt" \
+  -key "$tmp_dir/upstream.key" \
+  -www >"$tmp_dir/tls.out" 2>"$tmp_dir/tls.err" &
+tls_pid="$!"
+
+for _ in {1..60}; do
+  if python3 - "$upstream_port" <<'PY' >/dev/null 2>&1
+import socket
+import sys
+with socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=0.5):
+    pass
+PY
+  then
+    break
+  fi
+  sleep 0.25
+done
+
+curl \
+  -fsSk \
+  --max-time 10 \
+  --proxy "http://127.0.0.1:$relay_port" \
+  "https://127.0.0.1:$upstream_port/" | grep -qi "s_server"
+
+curl -fsS "http://127.0.0.1:$relay_port/api/events?limit=50" | grep -q '"event":"connect"'
+curl -fsS "http://127.0.0.1:$relay_port/api/events?limit=50" | grep -q '"event":"connect_closed"'
+
+echo "proxy smoke ok: relay=$relay_port upstream=$upstream_port"

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -1,12 +1,17 @@
 use std::{
     fs,
-    io::Cursor,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
 use anyhow::{anyhow, Result};
-use rustls::{ClientConfig, RootCertStore, ServerConfig};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use rustls::{
+    pki_types::{
+        CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer, PrivateSec1KeyDer,
+    },
+    ClientConfig, RootCertStore, ServerConfig,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AlpnProtocol {
@@ -78,10 +83,8 @@ pub fn server_tls_config(host: &str, ca_dir: &Path) -> Result<ServerConfig> {
     let (cert_path, key_path) = ensure_leaf_cert(host, ca_dir)?;
     let cert_file = fs::read(&cert_path)?;
     let key_file = fs::read(&key_path)?;
-    let certs = rustls_pemfile::certs(&mut Cursor::new(cert_file))
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-    let key = rustls_pemfile::private_key(&mut Cursor::new(key_file))?
-        .ok_or_else(|| anyhow!("leaf private key not found"))?;
+    let certs = load_cert_chain(&cert_file)?;
+    let key = load_private_key(&key_file)?;
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(certs, key)?;
@@ -175,6 +178,55 @@ fn run_quiet(command: &mut Command) -> Result<()> {
     } else {
         Err(anyhow!("command failed with status {status}"))
     }
+}
+
+fn load_cert_chain(pem: &[u8]) -> Result<Vec<CertificateDer<'static>>> {
+    let certs = decode_pem_blocks(pem, "CERTIFICATE")?;
+    if certs.is_empty() {
+        return Err(anyhow!("leaf certificate not found"));
+    }
+    Ok(certs.into_iter().map(CertificateDer::from).collect())
+}
+
+fn load_private_key(pem: &[u8]) -> Result<PrivateKeyDer<'static>> {
+    if let Some(key) = decode_first_pem_block(pem, "PRIVATE KEY")? {
+        return Ok(PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key)));
+    }
+    if let Some(key) = decode_first_pem_block(pem, "RSA PRIVATE KEY")? {
+        return Ok(PrivateKeyDer::from(PrivatePkcs1KeyDer::from(key)));
+    }
+    if let Some(key) = decode_first_pem_block(pem, "EC PRIVATE KEY")? {
+        return Ok(PrivateKeyDer::from(PrivateSec1KeyDer::from(key)));
+    }
+    Err(anyhow!("leaf private key not found"))
+}
+
+fn decode_first_pem_block(pem: &[u8], label: &str) -> Result<Option<Vec<u8>>> {
+    Ok(decode_pem_blocks(pem, label)?.into_iter().next())
+}
+
+fn decode_pem_blocks(pem: &[u8], label: &str) -> Result<Vec<Vec<u8>>> {
+    let text = std::str::from_utf8(pem)?;
+    let begin = format!("-----BEGIN {label}-----");
+    let end = format!("-----END {label}-----");
+    let mut rest = text;
+    let mut blocks = Vec::new();
+
+    while let Some(begin_index) = rest.find(&begin) {
+        let block_start = begin_index + begin.len();
+        let after_begin = &rest[block_start..];
+        let end_index = after_begin
+            .find(&end)
+            .ok_or_else(|| anyhow!("unterminated PEM block: {label}"))?;
+        let encoded: String = after_begin[..end_index]
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect();
+        blocks.push(STANDARD.decode(encoded)?);
+        rest = &after_begin[end_index + end.len()..];
+    }
+
+    Ok(blocks)
 }
 
 fn safe_cert_name(host: &str) -> String {


### PR DESCRIPTION
## Summary
- expand CI from Ubuntu-only Rust checks to Ubuntu/macOS Rust checks, macOS installer shell checks, proxy/TLS CONNECT smoke coverage, focused protocol/privacy regression tests, dependency audit, and Docker image build validation
- add a tag/manual release workflow that packages macOS artifacts and publishes a GHCR Docker image
- add a scoped conformance matrix, formal v0.1.0 release plan, and ready-to-post release announcement template
- remove the direct `rustls-pemfile` dependency after the new audit gate flagged it as unmaintained, replacing it with a small rustls-native PEM loader for the generated cert/key files

## Security finding addressed
Addresses the prototype maturity gap: version 0.1.0 had no tagged-release path and CI only covered formatting, unit tests, and clippy on Ubuntu. This PR adds CI/release gates for macOS, TLS/proxy smoke behavior, streaming/WebSocket regressions, dependency audit, Docker buildability, and a documented conformance matrix.

Discussions are currently disabled on the repository, so this PR includes `docs/formal-release-announcement.md` as the commentable announcement text to post once Discussions are enabled, or to reuse as an issue if we want an issue-based feedback thread.

## Tests
- `cargo fmt --all --check`
- `cargo test --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `bash -n src/install.sh src/uninstall.sh scripts/ci/proxy_smoke.sh`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "yaml ok #{f}" }' .github/workflows/ci.yml .github/workflows/release.yml`\n- `./scripts/ci/proxy_smoke.sh`\n- `git diff --check`\n- merge-tree check against `origin/main` produced no conflicts\n\nNot run locally:\n- `docker build -t litellm-relay:ci .` because Docker Desktop/daemon is not running locally (`Cannot connect to the Docker daemon`). The GitHub Actions `docker-build` job runs the Docker build in CI.\n- `cargo audit --deny warnings` because `cargo-audit` is not installed locally. The GitHub Actions `security-audit` job installs `cargo-audit` and runs this gate in CI.