### PR TITLE
RelayBarGlass: move budget bar under the hero spend

### DIFF
--- a/macos/RelayBarGlass/Sources/RelayBarGlass/UsageCard.swift
+++ b/macos/RelayBarGlass/Sources/RelayBarGlass/UsageCard.swift
@@ -30,18 +30,18 @@ struct UsageCard: View {
 
             if !selected.routedViaRelay {
                 notRoutedState
+                if model.keyBudget > 0 { budgetSection }
             } else if hasNoData {
                 emptyState
+                if model.keyBudget > 0 { budgetSection }
             } else {
                 hero
+                // Budget sits directly under the big spend number.
+                if model.keyBudget > 0 { budgetSection }
                 chartSection
                 modelMix
                 insights
                 footer
-            }
-
-            if model.keyBudget > 0 {
-                budgetSection
             }
         }
         .padding(16)


### PR DESCRIPTION
Moves the **relay-key budget bar** to sit **directly under the big "This month" spend number** in the RelayBarGlass menu bar card (it previously rendered at the bottom of the card).

- Routed tools: `hero → budget → spend/day → model mix → insights`.
- Not-routed / empty states: budget shown right under their message too.

Single-file change to `macos/RelayBarGlass/Sources/RelayBarGlass/UsageCard.swift`.

Stacked on top of #25 (base = `relaybar-glass`) so the diff shows only this change. The budget bar reads `keySpend / keyBudget · % used · Resets <date>` (key-level; the hero number is the selected tool's spend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)