### PR TITLE
fix(autoconfigure): Claude Code static-key support + clean summary output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +407,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -813,6 +832,7 @@ dependencies = [
  "brotli",
  "chrono",
  "clap",
+ "console",
  "flate2",
  "reqwest",
  "rustls",
@@ -1611,6 +1631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1861,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22"
 brotli = "7.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
+console = "0.15"
 flate2 = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["cookies", "json", "rustls-tls"] }
 rustls = "0.23"

--- a/src/ai_tools/autoconfigure.rs
+++ b/src/ai_tools/autoconfigure.rs
@@ -5,6 +5,7 @@
 //! a separate onboard command per tool per machine.
 
 use anyhow::Result;
+use url::Url;
 
 use crate::{
     ai_tools::{
@@ -99,13 +100,7 @@ fn autoconfigure_with(
         return Ok(());
     }
 
-    println!(
-        "Detected {} AI tool(s) to route through the Gateway:",
-        detected.len()
-    );
-    for Detection { tool, evidence } in &detected {
-        println!("  - {} ({evidence})", tool.label());
-    }
+    println!("Auto-configuring AI tools → {}", gateway_host());
     println!();
 
     let results: Vec<Configured> = detected
@@ -116,27 +111,39 @@ fn autoconfigure_with(
         })
         .collect();
 
-    let failures: Vec<&Configured> = results
-        .iter()
-        .filter(|configured| configured.outcome.is_err())
-        .collect();
-    let configured = results.len() - failures.len();
-
-    println!();
-    println!(
-        "Auto-configured {configured} of {} detected tool(s).",
-        results.len()
-    );
-    for failure in &failures {
-        if let Err(error) = &failure.outcome {
-            eprintln!("  ! {} was not configured: {error:#}", failure.tool.label());
+    for configured in &results {
+        match &configured.outcome {
+            Ok(()) => println!("  ✓  {}", configured.tool.label()),
+            Err(error) => println!("  –  {} — {}", configured.tool.label(), error),
         }
     }
 
-    if !failures.is_empty() && configured == 0 {
+    let failures = results
+        .iter()
+        .filter(|configured| configured.outcome.is_err())
+        .count();
+    let configured = results.len() - failures;
+
+    println!();
+    println!("Configured {configured} of {} detected tools.", results.len());
+
+    if failures > 0 && configured == 0 {
         anyhow::bail!("failed to configure any detected AI tool");
     }
     Ok(())
+}
+
+/// The Gateway host shown in the summary header. Loads the resolved settings and
+/// extracts the URL host, falling back to the raw URL when it can't be parsed.
+fn gateway_host() -> String {
+    let raw = match load_settings() {
+        Ok(settings) => settings.gateway.url,
+        Err(_) => return "the Gateway".to_string(),
+    };
+    Url::parse(&raw)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string))
+        .unwrap_or(raw)
 }
 
 /// Dispatch a single detected tool to its onboarder, forwarding overrides.
@@ -147,6 +154,8 @@ fn configure_tool(tool: AiTool, params: &AutoConfigureParams) -> Result<()> {
             authorize_url: params.authorize_url.clone(),
             team: params.team.clone(),
             model: None,
+            api_key: params.api_key.clone(),
+            quiet: true,
         }),
         AiTool::Codex => onboard_codex(CodexOnboardParams {
             gateway_url: params.gateway_url.clone(),
@@ -155,6 +164,7 @@ fn configure_tool(tool: AiTool, params: &AutoConfigureParams) -> Result<()> {
             model: None,
             env_key: params.env_key.clone(),
             api_key: params.api_key.clone(),
+            quiet: true,
         }),
         AiTool::ClaudeDesktop => onboard_desktop(OnboardDesktopParams {
             gateway_url: params.gateway_url.clone(),
@@ -164,6 +174,7 @@ fn configure_tool(tool: AiTool, params: &AutoConfigureParams) -> Result<()> {
             oidc_issuer: params.oidc_issuer.clone(),
             oidc_scopes: params.oidc_scopes.clone(),
             oidc_redirect_port: params.oidc_redirect_port,
+            quiet: true,
         }),
     }
 }

--- a/src/ai_tools/autoconfigure.rs
+++ b/src/ai_tools/autoconfigure.rs
@@ -5,6 +5,7 @@
 //! a separate onboard command per tool per machine.
 
 use anyhow::Result;
+use console::style;
 use url::Url;
 
 use crate::{
@@ -100,7 +101,11 @@ fn autoconfigure_with(
         return Ok(());
     }
 
-    println!("Auto-configuring AI tools → {}", gateway_host());
+    println!(
+        "{} {}",
+        style("Auto-configuring AI tools →").bold(),
+        style(gateway_host()).cyan().bold()
+    );
     println!();
 
     let results: Vec<Configured> = detected
@@ -112,9 +117,15 @@ fn autoconfigure_with(
         .collect();
 
     for configured in &results {
+        let label = style(configured.tool.label()).bold();
         match &configured.outcome {
-            Ok(()) => println!("  ✓  {}", configured.tool.label()),
-            Err(error) => println!("  –  {} — {}", configured.tool.label(), error),
+            Ok(()) => println!("  {}  {label}", style("✓").green().bold()),
+            Err(error) => println!(
+                "  {}  {label} {} {}",
+                style("–").yellow().bold(),
+                style("—").dim(),
+                style(error).dim(),
+            ),
         }
     }
 
@@ -125,7 +136,15 @@ fn autoconfigure_with(
     let configured = results.len() - failures;
 
     println!();
-    println!("Configured {configured} of {} detected tools.", results.len());
+    let summary = format!(
+        "Configured {configured} of {} detected tools.",
+        results.len()
+    );
+    if failures == 0 {
+        println!("{}", style(summary).green().bold());
+    } else {
+        println!("{}", style(summary).yellow());
+    }
 
     if failures > 0 && configured == 0 {
         anyhow::bail!("failed to configure any detected AI tool");

--- a/src/ai_tools/claude_cli/mod.rs
+++ b/src/ai_tools/claude_cli/mod.rs
@@ -324,15 +324,25 @@ mod tests {
         let root = merge_claude_settings(existing, &settings, &Credential::TokenHelper).unwrap();
 
         assert!(
-            root["apiKeyHelper"].as_str().unwrap().ends_with("claude-token"),
+            root["apiKeyHelper"]
+                .as_str()
+                .unwrap()
+                .ends_with("claude-token"),
             "token helper mode must set apiKeyHelper"
         );
         assert!(
-            root["env"].as_object().unwrap().get("ANTHROPIC_AUTH_TOKEN").is_none(),
+            root["env"]
+                .as_object()
+                .unwrap()
+                .get("ANTHROPIC_AUTH_TOKEN")
+                .is_none(),
             "token helper mode must remove a stale static ANTHROPIC_AUTH_TOKEN"
         );
         assert!(
-            !root["env"].as_object().unwrap().contains_key("ANTHROPIC_CUSTOM_HEADERS"),
+            !root["env"]
+                .as_object()
+                .unwrap()
+                .contains_key("ANTHROPIC_CUSTOM_HEADERS"),
             "no team means no custom headers"
         );
     }

--- a/src/ai_tools/claude_cli/mod.rs
+++ b/src/ai_tools/claude_cli/mod.rs
@@ -9,6 +9,20 @@ use crate::{
     system::home_dir,
 };
 
+/// How Claude Code should obtain the Gateway bearer credential. These are
+/// mutually exclusive: a static key lives in the `ANTHROPIC_AUTH_TOKEN` env var,
+/// while the token helper is a top-level `apiKeyHelper` command.
+#[derive(Debug, Default)]
+enum Credential<'a> {
+    /// Top-level `apiKeyHelper` running Relay's token helper (default). Claude
+    /// fetches a short-lived identity token on demand; no key on the device.
+    #[default]
+    TokenHelper,
+    /// Static gateway key written to `ANTHROPIC_AUTH_TOKEN` for environments
+    /// without an IdP.
+    StaticKey(&'a str),
+}
+
 /// Inputs for wiring Claude Code to route through the Gateway. Supplied by the
 /// MDM package (Jamf/Intune) or interactively; any field left unset falls back
 /// to the saved Relay config.
@@ -18,12 +32,19 @@ pub struct OnboardParams {
     pub authorize_url: Option<String>,
     pub team: Option<String>,
     pub model: Option<String>,
+    /// Static gateway key fallback for environments without an IdP.
+    pub api_key: Option<String>,
+    /// Suppress success output (used by autoconfigure, which prints its own
+    /// summary). Standalone `relay onboard` leaves this false.
+    pub quiet: bool,
 }
 
 /// Writes `~/.claude/settings.json` so `claude` sends requests to the Gateway
-/// with the team header, using Relay's token helper as the bearer source. The
-/// developer runs `claude` and signs in through their IdP on first use; no
-/// provider key ever touches the device.
+/// with the team header. By default the bearer source is Relay's token helper
+/// (`apiKeyHelper`) and the developer signs in through their IdP on first use,
+/// so no provider key ever touches the device. When a static Gateway key is
+/// supplied (or configured with no IdP), it is written to `ANTHROPIC_AUTH_TOKEN`
+/// instead.
 pub fn onboard(params: OnboardParams) -> Result<()> {
     let mut settings = load_settings()?;
     if let Some(gateway_url) = params.gateway_url {
@@ -39,19 +60,49 @@ pub fn onboard(params: OnboardParams) -> Result<()> {
         settings.claude.team = params.team;
     }
 
-    if settings.idp.authorize_url.trim().is_empty() {
-        bail!("onboarding requires an IdP authorize URL (--authorize-url or idp.authorize_url)");
-    }
+    // A static key resolves from --api-key, or from a saved gateway key when no
+    // IdP is configured. A configured IdP is always preferred.
+    let static_key = params
+        .api_key
+        .as_deref()
+        .filter(|key| !key.trim().is_empty())
+        .or_else(|| {
+            if settings.idp.authorize_url.trim().is_empty() {
+                settings
+                    .gateway
+                    .api_key
+                    .as_deref()
+                    .filter(|key| !key.trim().is_empty())
+            } else {
+                None
+            }
+        });
 
-    let settings_path = write_claude_settings(&settings)?;
+    let credential = match static_key {
+        Some(key) => Credential::StaticKey(key),
+        None if !settings.idp.authorize_url.trim().is_empty() => Credential::TokenHelper,
+        None => bail!(
+            "onboarding requires an IdP authorize URL (--authorize-url or idp.authorize_url) \
+             or a static Gateway key (--api-key or gateway.api_key)"
+        ),
+    };
+
+    let settings_path = write_claude_settings(&settings, &credential)?;
     save_settings(&settings)?;
 
-    println!("Claude Code is wired to {}", settings.gateway.url);
-    if let Some(team) = &settings.claude.team {
-        println!("Team header: x-litellm-team: {team}");
+    if !params.quiet {
+        println!("Claude Code is wired to {}", settings.gateway.url);
+        if let Some(team) = &settings.claude.team {
+            println!("Team header: x-litellm-team: {team}");
+        }
+        println!("Wrote {}", settings_path.display());
+        match &credential {
+            Credential::StaticKey(_) => println!("Using a static gateway key."),
+            Credential::TokenHelper => {
+                println!("Run `claude` and sign in through your browser on first use.");
+            }
+        }
     }
-    println!("Wrote {}", settings_path.display());
-    println!("Run `claude` and sign in through your browser on first use.");
     Ok(())
 }
 
@@ -67,14 +118,31 @@ fn claude_settings_path() -> PathBuf {
     home_dir().join(".claude").join("settings.json")
 }
 
-fn write_claude_settings(settings: &RelaySettings) -> Result<PathBuf> {
+fn write_claude_settings(settings: &RelaySettings, credential: &Credential) -> Result<PathBuf> {
     let path = claude_settings_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    let mut root = read_existing_settings(&path)?;
+    let root = read_existing_settings(&path)?;
+    let root = merge_claude_settings(root, settings, credential)?;
+
+    let serialized = serde_json::to_string_pretty(&Value::Object(root))?;
+    fs::write(&path, format!("{serialized}\n"))
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(path)
+}
+
+/// Merges Relay's managed keys into an existing `settings.json` object,
+/// preserving all other keys. The two credential modes are mutually exclusive:
+/// StaticKey writes `ANTHROPIC_AUTH_TOKEN` and drops any `apiKeyHelper`, while
+/// TokenHelper writes `apiKeyHelper` and drops `ANTHROPIC_AUTH_TOKEN`.
+fn merge_claude_settings(
+    mut root: Map<String, Value>,
+    settings: &RelaySettings,
+    credential: &Credential,
+) -> Result<Map<String, Value>> {
     let env = env_object(&mut root);
     env.insert(
         "ANTHROPIC_BASE_URL".into(),
@@ -95,16 +163,31 @@ fn write_claude_settings(settings: &RelaySettings) -> Result<PathBuf> {
             env.remove("ANTHROPIC_CUSTOM_HEADERS");
         }
     }
+    match credential {
+        Credential::StaticKey(key) => {
+            env.insert(
+                "ANTHROPIC_AUTH_TOKEN".into(),
+                Value::String((*key).to_string()),
+            );
+        }
+        Credential::TokenHelper => {
+            env.remove("ANTHROPIC_AUTH_TOKEN");
+        }
+    }
 
-    root.insert(
-        "apiKeyHelper".into(),
-        Value::String(token_helper_command()?),
-    );
+    match credential {
+        Credential::StaticKey(_) => {
+            root.remove("apiKeyHelper");
+        }
+        Credential::TokenHelper => {
+            root.insert(
+                "apiKeyHelper".into(),
+                Value::String(token_helper_command()?),
+            );
+        }
+    }
 
-    let serialized = serde_json::to_string_pretty(&Value::Object(root))?;
-    fs::write(&path, format!("{serialized}\n"))
-        .with_context(|| format!("failed to write {}", path.display()))?;
-    Ok(path)
+    Ok(root)
 }
 
 fn read_existing_settings(path: &PathBuf) -> Result<Map<String, Value>> {
@@ -182,5 +265,75 @@ mod tests {
         let command = token_helper_command().unwrap();
         assert!(command.ends_with("' claude-token"));
         assert!(command.starts_with('\''));
+    }
+
+    fn settings_with_team(team: Option<&str>) -> RelaySettings {
+        let mut settings = RelaySettings::default();
+        settings.gateway.url = "https://gateway.example.com".into();
+        settings.claude.model = "claude-sonnet-4-5".into();
+        settings.claude.team = team.map(str::to_string);
+        settings
+    }
+
+    #[test]
+    fn should_write_static_auth_token_and_drop_api_key_helper() {
+        let settings = settings_with_team(Some("engineering"));
+        let existing = serde_json::from_str::<Value>(r#"{"apiKeyHelper":"stale","keep":true}"#)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let root =
+            merge_claude_settings(existing, &settings, &Credential::StaticKey("sk-static-123"))
+                .unwrap();
+
+        assert_eq!(
+            root["env"]["ANTHROPIC_BASE_URL"],
+            Value::String("https://gateway.example.com".into())
+        );
+        assert_eq!(
+            root["env"]["ANTHROPIC_MODEL"],
+            Value::String("claude-sonnet-4-5".into())
+        );
+        assert_eq!(
+            root["env"]["ANTHROPIC_CUSTOM_HEADERS"],
+            Value::String("x-litellm-team: engineering".into())
+        );
+        assert_eq!(
+            root["env"]["ANTHROPIC_AUTH_TOKEN"],
+            Value::String("sk-static-123".into())
+        );
+        assert!(
+            !root.contains_key("apiKeyHelper"),
+            "static key mode must remove any apiKeyHelper so the two do not conflict"
+        );
+        assert_eq!(root["keep"], Value::Bool(true));
+    }
+
+    #[test]
+    fn should_write_api_key_helper_and_drop_static_auth_token() {
+        let settings = settings_with_team(None);
+        let existing =
+            serde_json::from_str::<Value>(r#"{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-stale"}}"#)
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .clone();
+
+        let root = merge_claude_settings(existing, &settings, &Credential::TokenHelper).unwrap();
+
+        assert!(
+            root["apiKeyHelper"].as_str().unwrap().ends_with("claude-token"),
+            "token helper mode must set apiKeyHelper"
+        );
+        assert!(
+            root["env"].as_object().unwrap().get("ANTHROPIC_AUTH_TOKEN").is_none(),
+            "token helper mode must remove a stale static ANTHROPIC_AUTH_TOKEN"
+        );
+        assert!(
+            !root["env"].as_object().unwrap().contains_key("ANTHROPIC_CUSTOM_HEADERS"),
+            "no team means no custom headers"
+        );
     }
 }

--- a/src/ai_tools/claude_desktop/mod.rs
+++ b/src/ai_tools/claude_desktop/mod.rs
@@ -159,7 +159,8 @@ fn write_managed_settings(document: &Map<String, Value>) -> Result<PathBuf> {
     }
 
     let serialized = serde_json::to_string_pretty(&Value::Object(document.clone()))?;
-    fs::write(&path, format!("{serialized}\n")).map_err(|error| managed_write_error(error, &path))?;
+    fs::write(&path, format!("{serialized}\n"))
+        .map_err(|error| managed_write_error(error, &path))?;
     Ok(path)
 }
 

--- a/src/ai_tools/claude_desktop/mod.rs
+++ b/src/ai_tools/claude_desktop/mod.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use serde_json::{json, Map, Value};
 
 use crate::config::{load_settings, save_settings, RelaySettings};
@@ -23,6 +23,9 @@ pub struct OnboardDesktopParams {
     pub oidc_issuer: Option<String>,
     pub oidc_scopes: Option<String>,
     pub oidc_redirect_port: Option<u16>,
+    /// Suppress success output (used by autoconfigure, which prints its own
+    /// summary). Standalone `relay onboard-claude-desktop` leaves this false.
+    pub quiet: bool,
 }
 
 /// Writes `/etc/claude-desktop/managed-settings.json` so Claude Desktop routes
@@ -64,19 +67,21 @@ pub fn onboard_desktop(params: OnboardDesktopParams) -> Result<()> {
     let path = write_managed_settings(&document)?;
     save_settings(&settings)?;
 
-    println!("Claude Desktop is wired to {}", settings.gateway.url);
-    match &sso {
-        Some(sso) => {
-            println!(
-                "Sign-in: OIDC issuer {} (client {})",
-                sso.issuer, sso.client_id
-            );
-            println!("Developers click \"Sign in to your organization\" on first launch.");
+    if !params.quiet {
+        println!("Claude Desktop is wired to {}", settings.gateway.url);
+        match &sso {
+            Some(sso) => {
+                println!(
+                    "Sign-in: OIDC issuer {} (client {})",
+                    sso.issuer, sso.client_id
+                );
+                println!("Developers click \"Sign in to your organization\" on first launch.");
+            }
+            None => println!("Credential: static Gateway API key"),
         }
-        None => println!("Credential: static Gateway API key"),
+        println!("Wrote {}", path.display());
+        println!("Restart Claude Desktop to pick up the managed configuration.");
     }
-    println!("Wrote {}", path.display());
-    println!("Restart Claude Desktop to pick up the managed configuration.");
     Ok(())
 }
 
@@ -150,24 +155,24 @@ fn managed_settings_path() -> PathBuf {
 fn write_managed_settings(document: &Map<String, Value>) -> Result<PathBuf> {
     let path = managed_settings_path();
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!(
-                "failed to create {} (Claude Desktop requires this managed directory to be \
-                 root-owned; re-run with sudo)",
-                parent.display()
-            )
-        })?;
+        fs::create_dir_all(parent).map_err(|error| managed_write_error(error, parent))?;
     }
 
     let serialized = serde_json::to_string_pretty(&Value::Object(document.clone()))?;
-    fs::write(&path, format!("{serialized}\n")).with_context(|| {
-        format!(
-            "failed to write {} (Claude Desktop only honors a root-owned managed file; re-run \
-             with sudo)",
-            path.display()
-        )
-    })?;
+    fs::write(&path, format!("{serialized}\n")).map_err(|error| managed_write_error(error, &path))?;
     Ok(path)
+}
+
+/// Maps a filesystem error on the managed `/etc/claude-desktop` path to a
+/// concise, actionable message. Permission errors get a short "needs sudo" hint
+/// (surfaced verbatim in the autoconfigure summary) instead of the raw
+/// "Permission denied (os error 13)".
+fn managed_write_error(error: std::io::Error, path: &std::path::Path) -> anyhow::Error {
+    if error.kind() == std::io::ErrorKind::PermissionDenied {
+        anyhow!("needs sudo (managed dir /etc/claude-desktop must be root-owned)")
+    } else {
+        anyhow::Error::new(error).context(format!("failed to write {}", path.display()))
+    }
 }
 
 #[cfg(test)]

--- a/src/ai_tools/codex/mod.rs
+++ b/src/ai_tools/codex/mod.rs
@@ -51,6 +51,9 @@ pub struct CodexOnboardParams {
     pub env_key: Option<String>,
     /// Static gateway key fallback for environments without an IdP.
     pub api_key: Option<String>,
+    /// Suppress success output (used by autoconfigure, which prints its own
+    /// summary). Standalone `relay onboard-codex` leaves this false.
+    pub quiet: bool,
 }
 
 /// Writes `~/.codex/config.toml` so `codex` sends requests to the Gateway
@@ -102,30 +105,32 @@ pub fn onboard(params: CodexOnboardParams) -> Result<()> {
     let config_path = write_codex_config(&settings, &credential, &exe)?;
     save_settings(&settings)?;
 
-    println!(
-        "Codex is wired to {} (provider `{}`, model `{}`)",
-        provider_base_url(&settings),
-        settings.codex.provider_id,
-        settings.codex.model
-    );
-    if let Some(team) = &settings.codex.team {
-        println!("Team header: x-litellm-team: {team}");
+    if !params.quiet {
+        println!(
+            "Codex is wired to {} (provider `{}`, model `{}`)",
+            provider_base_url(&settings),
+            settings.codex.provider_id,
+            settings.codex.model
+        );
+        if let Some(team) = &settings.codex.team {
+            println!("Team header: x-litellm-team: {team}");
+        }
+        match &credential {
+            Credential::TokenHelper => {
+                println!("Codex fetches a short-lived identity token via `relay codex-token`.");
+            }
+            Credential::EnvKey(var) => {
+                println!(
+                    "Codex reads the bearer key from ${var}. Populate it with the identity token, e.g.\n  export {var}=\"$({exe} codex-token)\""
+                );
+            }
+            Credential::StaticKey(_) => {
+                println!("Using a static gateway key from --api-key.");
+            }
+        }
+        println!("Wrote {}", config_path.display());
+        println!("Run `codex` and sign in through your browser on first use.");
     }
-    match &credential {
-        Credential::TokenHelper => {
-            println!("Codex fetches a short-lived identity token via `relay codex-token`.");
-        }
-        Credential::EnvKey(var) => {
-            println!(
-                "Codex reads the bearer key from ${var}. Populate it with the identity token, e.g.\n  export {var}=\"$({exe} codex-token)\""
-            );
-        }
-        Credential::StaticKey(_) => {
-            println!("Using a static gateway key from --api-key.");
-        }
-    }
-    println!("Wrote {}", config_path.display());
-    println!("Run `codex` and sign in through your browser on first use.");
     Ok(())
 }
 

--- a/src/ai_tools/detect.rs
+++ b/src/ai_tools/detect.rs
@@ -121,6 +121,10 @@ impl DetectContext {
 #[derive(Debug, Clone)]
 pub struct Detection {
     pub tool: AiTool,
+    /// Human-readable reason the tool was detected. Retained for diagnostics and
+    /// asserted in detection tests; the clean autoconfigure summary no longer
+    /// prints it, so it is otherwise unread in the binary.
+    #[allow(dead_code)]
     pub evidence: String,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,6 +77,9 @@ enum CommandKind {
         team: Option<String>,
         #[arg(long)]
         model: Option<String>,
+        /// Static gateway key fallback for environments without an IdP.
+        #[arg(long)]
+        api_key: Option<String>,
     },
     /// Wire Claude Desktop (third-party mode) to route through the Gateway.
     ///
@@ -191,11 +194,14 @@ async fn run_command(command: CommandKind) -> Result<()> {
             authorize_url,
             team,
             model,
+            api_key,
         } => onboard(OnboardParams {
             gateway_url,
             authorize_url,
             team,
             model,
+            api_key,
+            quiet: false,
         }),
         CommandKind::OnboardClaudeDesktop {
             gateway_url,
@@ -213,6 +219,7 @@ async fn run_command(command: CommandKind) -> Result<()> {
             oidc_issuer,
             oidc_scopes,
             oidc_redirect_port,
+            quiet: false,
         }),
         CommandKind::ClaudeToken => print_token(),
         CommandKind::OnboardCodex {
@@ -229,6 +236,7 @@ async fn run_command(command: CommandKind) -> Result<()> {
             model,
             env_key,
             api_key,
+            quiet: false,
         }),
         CommandKind::CodexToken => print_codex_token(),
     }


### PR DESCRIPTION
## Problem

Running `relay autoconfigure` on a static-key (non-IdP) setup skipped Claude Code:

```
Auto-configured 1 of 3 detected tool(s).
  ! Claude Code CLI was not configured: onboarding requires an IdP authorize URL (--authorize-url or idp.authorize_url)
  ! Claude Desktop was not configured: failed to create /etc/claude-desktop ... Permission denied (os error 13)
```

Codex configured fine with the saved Gateway key, but Claude Code's onboarder was **IdP-only** (always wrote the token-helper `apiKeyHelper` and bailed without an `authorize_url`), and `autoconfigure` never even forwarded the key to it. The output was also noisy — each tool's onboarder printed its own verbose lines that interleaved with the summary.

## Fix

**Claude Code static key (symmetry with Codex)**
- `OnboardParams` gains `api_key`. `onboard()` resolves a credential: static key from `--api-key`, or fall back to `gateway.api_key` when no IdP is configured; otherwise use the IdP token helper; otherwise bail with a message naming both options.
- `write_claude_settings` writes `ANTHROPIC_AUTH_TOKEN` + drops `apiKeyHelper` for the static path (and the reverse for the token-helper path), preserving all other settings.
- `--api-key` added to `relay onboard`.

**Clean autoconfigure output**
- Onboarders take a `quiet` flag; `autoconfigure` runs them quietly and prints one aligned summary:

```
Auto-configuring AI tools → gateway.litellm-sandbox.ai

  ✓  Claude Code CLI
  –  Claude Desktop — needs sudo (managed dir /etc/claude-desktop must be root-owned)
  ✓  Codex (CLI, VS Code, macOS app)

Configured 2 of 3 detected tools.
```
- Claude Desktop permission failures now show a concise "needs sudo" reason instead of raw `Permission denied (os error 13)`.

## Tests
`cargo build --release` clean; `cargo test` → **61 passed, 0 failed** (incl. 2 new claude_cli credential tests: static drops the helper, token-helper drops the stale auth token, other keys preserved). Verified live: `relay autoconfigure` now configures Claude Code + Codex and prints the summary above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)